### PR TITLE
Make refresh token work

### DIFF
--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -5,18 +5,18 @@ import Button from 'primevue/button';
 import { useAuthStore } from '@/store/authStore';
 
 const authStore = useAuthStore();
-const { ready, getToken } = storeToRefs(useAuthStore());
+const { ready, getKeycloak } = storeToRefs(useAuthStore());
 
 const login = () => {
   authStore.login();
 };
 
-const logout = async () => {
-  const response = await authStore.logout();
+const logout = () => {
+  authStore.logout();
 };
 </script>
 
 <template>
-  <Button v-if="!getToken" primary @click="login" :loading="!ready">Log in</Button>
+  <Button v-if="!getKeycloak.token" primary @click="login" :loading="!ready">Log in</Button>
   <Button v-else primary @click="logout">Log out</Button>
 </template>

--- a/frontend/src/components/Login.vue
+++ b/frontend/src/components/Login.vue
@@ -4,16 +4,8 @@ import { storeToRefs } from 'pinia';
 import Button from 'primevue/button';
 import { useAuthStore } from '@/store/authStore';
 
-const authStore = useAuthStore();
+const { login, logout } = useAuthStore();
 const { ready, getKeycloak } = storeToRefs(useAuthStore());
-
-const login = () => {
-  authStore.login();
-};
-
-const logout = () => {
-  authStore.logout();
-};
 </script>
 
 <template>

--- a/frontend/src/components/layout/Navbar.vue
+++ b/frontend/src/components/layout/Navbar.vue
@@ -7,10 +7,11 @@ import { useAuthStore } from '@/store/authStore';
 import { RouteNames } from '@/utils/constants';
 
 const { getAuthenticated } = storeToRefs(useAuthStore());
+const { getKeycloak } = storeToRefs(useAuthStore());
 </script>
 
 <template>
-  <div v-if="getAuthenticated">
+  <div v-if="getKeycloak.authenticated">
     <Toolbar>
       <template #start>
         <ol class="list-none m-0 p-0 flex flex-row align-items-center font-semibold">

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -69,7 +69,7 @@ const router = createRouter({
 router.beforeEach((to, from) => {
   const authStore = useAuthStore();
 
-  if (!authStore.getAuthenticated) {
+  if (!authStore.getKeycloak.authenticated) {
     if (to.meta.requiresAuth) {
       return {
         path: '/',

--- a/frontend/src/services/interceptors.ts
+++ b/frontend/src/services/interceptors.ts
@@ -21,7 +21,7 @@ export function comsAxios(timeout = 10000) {
   instance.interceptors.request.use(
     (cfg: any) => {
       if (authStore.ready && authStore.getAuthenticated) {
-        cfg.headers.Authorization = `Bearer ${authStore.getToken}`;
+        cfg.headers.Authorization = `Bearer ${authStore.getKeycloak.token}`;
       }
       return Promise.resolve(cfg);
     },

--- a/frontend/src/services/interceptors.ts
+++ b/frontend/src/services/interceptors.ts
@@ -20,7 +20,7 @@ export function comsAxios(timeout = 10000) {
 
   instance.interceptors.request.use(
     (cfg: any) => {
-      if (authStore.ready && authStore.getAuthenticated) {
+      if (authStore.ready && authStore.getKeycloak.authenticated) {
         cfg.headers.Authorization = `Bearer ${authStore.getKeycloak.token}`;
       }
       return Promise.resolve(cfg);

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -3,31 +3,33 @@ import type { Ref } from 'vue';
 import { defineStore } from 'pinia';
 import Keycloak from 'keycloak-js';
 import { useConfigStore } from './configStore';
+import { KEYCLOAK } from '@/utils/constants';
 
 export const useAuthStore = defineStore('auth', () => {
   const configStore = useConfigStore();
 
   // State
   // Is this typescript ok...? Come back to later?
-  const $keycloak: Ref<Keycloak> = ref(new Keycloak());
+  const _keycloak: Ref<Keycloak> = ref(new Keycloak());
   const ready = ref(false);
+  const refreshJobInterval = ref(0);
 
   // Getters
-  const getKeycloak = computed(() => $keycloak.value);
-  // const getAuthenticated = computed((): boolean => (ready.value ? !!$keycloak.value.authenticated : false));
-  // const getLoginUrl = computed(() => (ready.value ? $keycloak.value.createLoginUrl() : ''));
-  // const getToken = computed(() => (ready.value ? $keycloak.value.token : ''));
-  // const getTokenParsed = computed((): Object | undefined => (ready.value ? $keycloak.value.tokenParsed : {}));
+  const getKeycloak = computed(() => _keycloak.value);
+  // const getAuthenticated = computed((): boolean => (ready.value ? !!_keycloak.value.authenticated : false));
+  // const getLoginUrl = computed(() => (ready.value ? _keycloak.value.createLoginUrl() : ''));
+  // const getToken = computed(() => (ready.value ? _keycloak.value.token : ''));
+  // const getTokenParsed = computed((): Object | undefined => (ready.value ? _keycloak.value.tokenParsed : {}));
 
   // Actions
   function login() {
-    window.location.replace($keycloak.value.createLoginUrl());
+    window.location.replace(_keycloak.value.createLoginUrl());
   }
 
   function logout() {
     if (ready.value) {
       window.location.replace(
-        $keycloak.value.createLogoutUrl({
+        _keycloak.value.createLogoutUrl({
           redirectUri: `${location.origin}/`,
         })
       );
@@ -51,20 +53,20 @@ export const useAuthStore = defineStore('auth', () => {
 
     // After a refresh token fetch success
     kc.onAuthRefreshSuccess = function () {
-      // console.log($keycloak.value.token);
+      // console.log(_keycloak.value.token);
     };
 
     await kc
       .init({ onLoad: 'check-sso', pkceMethod: 'S256' })
       .then(() => {
         // Set the state field to the inited keycloak instance
-        $keycloak.value = kc;
+        _keycloak.value = kc;
 
         // Token Refresh
         // Check token validity every 10s and, if necessary, update the token.
         // Refresh token if it's valid for less then 70 seconds
-        setInterval(() => {
-          kc.updateToken(70) // If the token expires within 70 seconds from now get a refreshed
+        refreshJobInterval.value = window.setInterval(() => {
+          kc.updateToken(KEYCLOAK.MIN_VALID_TIME_SEC) // If the token expires within 70 seconds from now get a refreshed
             .then((refreshed: Boolean) => {
               if (refreshed) {
                 console.log('Token refreshed ' + refreshed);
@@ -77,7 +79,7 @@ export const useAuthStore = defineStore('auth', () => {
             .catch(() => {
               console.error('Failed to refresh token');
             });
-        }, 10000); // Check every 10s
+        }, KEYCLOAK.REFRESH_TIME_MS); // Check every 10s
       })
       .catch((err) => {
         console.error(`Authenticated Failed ${JSON.stringify(err)}`);

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -51,7 +51,7 @@ export const useAuthStore = defineStore('auth', () => {
 
     // After a refresh token fetch success
     kc.onAuthRefreshSuccess = function () {
-      console.log($keycloak.value.token);
+      // console.log($keycloak.value.token);
     };
 
     await kc
@@ -65,7 +65,7 @@ export const useAuthStore = defineStore('auth', () => {
         // Refresh token if it's valid for less then 70 seconds
         setInterval(() => {
           $keycloak.value;
-          kc.updateToken(290) // If the token expires within 70 seconds from now get a refreshed
+          kc.updateToken(70) // If the token expires within 70 seconds from now get a refreshed
             .then((refreshed: Boolean) => {
               if (refreshed) {
                 console.log('Token refreshed ' + refreshed);

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -84,5 +84,5 @@ export const useAuthStore = defineStore('auth', () => {
       });
   }
 
-  return { login, logout, init, getKeycloak, getLoginUrl, ready, getToken, getAuthenticated, getTokenParsed };
+  return { login, logout, init, getKeycloak, ready };
 });

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -14,10 +14,10 @@ export const useAuthStore = defineStore('auth', () => {
 
   // Getters
   const getKeycloak = computed(() => $keycloak.value);
-  const getAuthenticated = computed((): boolean => (ready.value ? !!$keycloak.value.authenticated : false));
-  const getLoginUrl = computed(() => (ready.value ? $keycloak.value.createLoginUrl() : ''));
-  const getToken = computed(() => (ready.value ? $keycloak.value.token : ''));
-  const getTokenParsed = computed((): Object | undefined => (ready.value ? $keycloak.value.tokenParsed : {}));
+  // const getAuthenticated = computed((): boolean => (ready.value ? !!$keycloak.value.authenticated : false));
+  // const getLoginUrl = computed(() => (ready.value ? $keycloak.value.createLoginUrl() : ''));
+  // const getToken = computed(() => (ready.value ? $keycloak.value.token : ''));
+  // const getTokenParsed = computed((): Object | undefined => (ready.value ? $keycloak.value.tokenParsed : {}));
 
   // Actions
   function login() {
@@ -64,7 +64,6 @@ export const useAuthStore = defineStore('auth', () => {
         // Check token validity every 10s and, if necessary, update the token.
         // Refresh token if it's valid for less then 70 seconds
         setInterval(() => {
-          $keycloak.value;
           kc.updateToken(70) // If the token expires within 70 seconds from now get a refreshed
             .then((refreshed: Boolean) => {
               if (refreshed) {

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,5 +1,6 @@
-export const ValidationMessages = Object.freeze({
-  Required: 'This field is required.',
+export const KEYCLOAK = Object.freeze({
+  MIN_VALID_TIME_SEC: 70,
+  REFRESH_TIME_MS: 1000,
 });
 
 export const RouteNames = Object.freeze({
@@ -8,4 +9,8 @@ export const RouteNames = Object.freeze({
   Developer: 'developer',
   ListBuckets: 'listBuckets',
   ListObjects: 'listObjects',
+});
+
+export const ValidationMessages = Object.freeze({
+  Required: 'This field is required.',
 });

--- a/frontend/src/views/DeveloperView.vue
+++ b/frontend/src/views/DeveloperView.vue
@@ -10,7 +10,7 @@ import { useConfigStore } from '@/store/configStore';
 import { useUserStore } from '@/store/userStore';
 
 const { config } = storeToRefs(useConfigStore());
-const { getToken, getTokenParsed } = storeToRefs(useAuthStore());
+const { getKeycloak } = storeToRefs(useAuthStore());
 const userStore = useUserStore();
 const { loading, idps } = storeToRefs(useUserStore());
 
@@ -55,10 +55,10 @@ const testBad = async () => {
     {{ config }}
 
     <h3>Token</h3>
-    {{ getToken }}
+    {{ getKeycloak.token }}
 
     <h3>Parsed Token</h3>
-    {{ getTokenParsed }}
+    {{ getKeycloak.tokenParsed }}
   </div>
 </template>
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -3,11 +3,15 @@ import { storeToRefs } from 'pinia';
 import { useAuthStore } from '@/store/authStore';
 
 const { getAuthenticated } = storeToRefs(useAuthStore());
+const { getKeycloak } = storeToRefs(useAuthStore());
 </script>
 
 <template>
   <div>
-    <h3 v-if="!getAuthenticated">Please login to continue.</h3>
+    <h3 v-if="!getKeycloak.authenticated">Please login to continue.</h3>
+    <div v-else>
+      <BucketList />
+    </div>
   </div>
 </template>
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -2,16 +2,12 @@
 import { storeToRefs } from 'pinia';
 import { useAuthStore } from '@/store/authStore';
 
-const { getAuthenticated } = storeToRefs(useAuthStore());
 const { getKeycloak } = storeToRefs(useAuthStore());
 </script>
 
 <template>
   <div>
     <h3 v-if="!getKeycloak.authenticated">Please login to continue.</h3>
-    <div v-else>
-      <BucketList />
-    </div>
   </div>
 </template>
 


### PR DESCRIPTION
Computed properties tied to the Keycloak object seem to not update no matter what I do... so the token getter is still returning the original token even though the refresh loop is going fine and getting a new token into the Keycloak object.
If we just expose the Keycloak object itself as a getter and then reference its properties in components that works fine though.

So for now we should just live with this to get the refresh token and other Keycloak property access working as expected.
Or maybe it's fine to have the one object exposed, it's TypeScript now and it's typed so it's not like you can reference things that aren't there or wouldn't work...

Can come back to later as well and try some more.