### PR TITLE
Add missing information to object details screens

### DIFF
--- a/frontend/src/components/form/GridRow.vue
+++ b/frontend/src/components/form/GridRow.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+defineProps({
+  label: {
+    type: String,
+    default: undefined
+  },
+  value: {
+    type: String,
+    default: undefined
+  },
+  link: {
+    type: Object,
+    default: undefined
+  }
+});
+
+</script>
+
+<template>
+  <div
+    v-if="value && label"
+    class="col-3"
+  >
+    {{ label }}:
+  </div>
+  <div
+    v-if="value && link"
+    class="col-9"
+  >
+    <router-link
+      :to="link"
+    >
+      {{ value }}
+    </router-link>
+  </div>
+  <div
+    v-if="value && !link"
+    class="col-9"
+  >
+    {{ value }}
+  </div>
+</template>

--- a/frontend/src/components/form/GridRow.vue
+++ b/frontend/src/components/form/GridRow.vue
@@ -13,7 +13,6 @@ defineProps({
     default: undefined
   }
 });
-
 </script>
 
 <template>

--- a/frontend/src/components/object/DeleteObjectButton.vue
+++ b/frontend/src/components/object/DeleteObjectButton.vue
@@ -1,19 +1,16 @@
 <script setup lang="ts">
-// Types
-import { ButtonMode } from '@/interfaces/common/enums';
 import { ref, type PropType } from 'vue';
-
-// PrimeVue / Fonts / etc
-import Button from 'primevue/button';
-import { useConfirm } from 'primevue/useconfirm';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
+import { useConfirm } from 'primevue/useconfirm';
 import { useToast } from 'primevue/usetoast';
-// State
+
+import { ButtonMode } from '@/interfaces/common/enums';
 import { useObjectStore } from '@/store/objectStore';
-const objectStore = useObjectStore();
 
 const confirm = useConfirm();
+const objectStore = useObjectStore();
 const toast = useToast();
 
 // Props

--- a/frontend/src/components/object/DownloadObjectButton.vue
+++ b/frontend/src/components/object/DownloadObjectButton.vue
@@ -1,13 +1,10 @@
 <script setup lang="ts">
-// Types
-import { ButtonMode } from '@/interfaces/common/enums';
 import { ref, type PropType } from 'vue';
-
-// PrimeVue/Font
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-// State
+
+import { ButtonMode } from '@/interfaces/common/enums';
 import { useObjectStore } from '@/store';
 
 const objectStore = useObjectStore();

--- a/frontend/src/components/object/ObjectAccess.vue
+++ b/frontend/src/components/object/ObjectAccess.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia';
 import { useUserStore } from '@/store';
 import { Permissions } from '@/utils/constants';
 
+import type { Ref } from 'vue';
 import type { Permission } from '@/interfaces';
 
 const userStore = useUserStore();
@@ -16,7 +17,7 @@ const props = defineProps({
   }
 });
 
-const managedBy = ref();
+const managedBy: Ref<string | undefined> = ref();
 
 async function getUserData() {
   const uniqueIds = [...new Set(props.objectAccess?.permissions

--- a/frontend/src/components/object/ObjectAccess.vue
+++ b/frontend/src/components/object/ObjectAccess.vue
@@ -1,12 +1,40 @@
-<!-- <script setup lang="ts">
+<script setup lang="ts">
+import { onMounted, ref, watch} from 'vue';
+import { storeToRefs } from 'pinia';
+import { useUserStore } from '@/store';
+import { Permissions } from '@/utils/constants';
 
-defineProps({
+import type { Permission } from '@/interfaces';
+
+const userStore = useUserStore();
+const { userSearch } = storeToRefs(userStore);
+
+const props = defineProps({
   objectAccess: {
     type: Object,
     default: undefined
   }
 });
 
+const managedBy = ref();
+
+async function getUserData() {
+  const uniqueIds = [...new Set(props.objectAccess?.permissions
+    .filter( (x: Permission) => x.permCode === Permissions.MANAGE )
+    .map((x: Permission) => x.userId))];
+
+  await userStore.searchUsers({userId: uniqueIds} );
+
+  managedBy.value = userSearch.value.map( x => x.fullName ).join( ', ');
+}
+
+onMounted(() => {
+  getUserData();
+});
+
+watch( props, async () => {
+  await getUserData();
+});
 </script>
 
 <template>
@@ -20,7 +48,7 @@ defineProps({
       Managed by:
     </div>
     <div class="col-9">
-      {{ objectAccess?.managedBy }}
+      {{ managedBy }}
     </div>
   </div>
-</template> -->
+</template>

--- a/frontend/src/components/object/ObjectAccess.vue
+++ b/frontend/src/components/object/ObjectAccess.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, watch} from 'vue';
+import { onMounted, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useUserStore } from '@/store';
 import { Permissions } from '@/utils/constants';
@@ -11,7 +11,7 @@ const userStore = useUserStore();
 const { userSearch } = storeToRefs(userStore);
 
 const props = defineProps({
-  objectAccess: {
+  objectInfo: {
     type: Object,
     default: undefined
   }
@@ -20,9 +20,9 @@ const props = defineProps({
 const managedBy: Ref<string | undefined> = ref();
 
 async function getUserData() {
-  const uniqueIds = [...new Set(props.objectAccess?.permissions
+  const uniqueIds = [...new Set(props.objectInfo?.permissions
     .filter( (x: Permission) => x.permCode === Permissions.MANAGE )
-    .map((x: Permission) => x.userId))];
+    .map( (x: Permission) => x.userId) )];
 
   await userStore.searchUsers({userId: uniqueIds} );
 
@@ -33,8 +33,8 @@ onMounted(() => {
   getUserData();
 });
 
-watch( props, async () => {
-  await getUserData();
+watch( props, () => {
+  getUserData();
 });
 </script>
 

--- a/frontend/src/components/object/ObjectFileDetails.vue
+++ b/frontend/src/components/object/ObjectFileDetails.vue
@@ -33,9 +33,9 @@ const { currentUser } = storeToRefs(useUserStore());
 const objectInfo: Ref<COMSObject> = ref({} as COMSObject);
 const isInfoLoaded: Ref<Boolean> = ref(false);
 
-const permissionsVisible = ref(false);
-const permissionsObjectId = ref('');
-const permissionsObjectName = ref('');
+const permissionsVisible: Ref<boolean> = ref(false);
+const permissionsObjectId: Ref<string> = ref('');
+const permissionsObjectName: Ref<string> = ref('');
 
 const getObjectInfo = (objId: string) => {
   try {
@@ -97,8 +97,8 @@ onMounted(() => {
       v-if="isInfoLoaded"
       class="pl-2"
     >
-      <ObjectProperties :object-properties="objectInfo" />
-      <ObjectAccess :object-access="objectInfo" />
+      <ObjectProperties :object-info="objectInfo" />
+      <ObjectAccess :object-info="objectInfo" />
       <ObjectMetadata :object-metadata="objectInfo.metadata" />
       <ObjectTag :object-tag="objectInfo.tag" />
     </div>

--- a/frontend/src/components/object/ObjectFileDetails.vue
+++ b/frontend/src/components/object/ObjectFileDetails.vue
@@ -6,25 +6,27 @@ import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
 import { useToast } from 'primevue/usetoast';
 
-import DeleteObjectButton from '@/components/object/DeleteObjectButton.vue';
-import DownloadObjectButton from '@/components/object/DownloadObjectButton.vue';
-import ObjectAccess from '@/components/object/ObjectAccess.vue';
-import ObjectMetadata from '@/components/object/ObjectMetadata.vue';
-import ObjectPermission from '@/components/object/ObjectPermission.vue';
-import ObjectProperties from '@/components/object/ObjectProperties.vue';
-import ObjectTag from '@/components/object/ObjectTag.vue';
-import { useBucketStore, useObjectStore, useUserStore } from '@/store';
+import {
+  DeleteObjectButton,
+  DownloadObjectButton,
+  ObjectAccess,
+  ObjectMetadata,
+  ObjectPermission,
+  ObjectProperties,
+  ObjectTag
+} from '@/components/object';
+
+import { useObjectStore, useUserStore } from '@/store';
 import { Permissions } from '@/utils/constants';
 
 import type { Ref } from 'vue';
-import type { COMSObject, Permission } from '@/interfaces';
+import type { COMSObject } from '@/interfaces';
 import { ButtonMode } from '@/interfaces/common/enums';
 
 const objectStore = useObjectStore();
 const toast = useToast();
 const route = useRoute();
 
-const { selectedBucketPermissionsForUser } = storeToRefs(useBucketStore());
 const { objectList } = storeToRefs(objectStore);
 const { currentUser } = storeToRefs(useUserStore());
 

--- a/frontend/src/components/object/ObjectList.vue
+++ b/frontend/src/components/object/ObjectList.vue
@@ -6,11 +6,12 @@ import { storeToRefs } from 'pinia';
 import Button from 'primevue/button';
 import { useToast } from 'primevue/usetoast';
 
-import DeleteObjectButton from '@/components/object/DeleteObjectButton.vue';
-import DownloadObjectButton from '@/components/object/DownloadObjectButton.vue';
-import ObjectSidebar from '@/components/object/ObjectSidebar.vue';
-import ObjectTable from '@/components/object/ObjectTable.vue';
-import ObjectUpload from '@/components/object/ObjectUpload.vue';
+import {
+  DeleteObjectButton,
+  DownloadObjectButton,
+  ObjectSidebar,
+  ObjectTable,
+  ObjectUpload} from '@/components/object';
 import { ButtonMode } from '@/interfaces/common/enums';
 import { useBucketStore, useObjectStore } from '@/store';
 

--- a/frontend/src/components/object/ObjectList.vue
+++ b/frontend/src/components/object/ObjectList.vue
@@ -11,7 +11,8 @@ import {
   DownloadObjectButton,
   ObjectSidebar,
   ObjectTable,
-  ObjectUpload} from '@/components/object';
+  ObjectUpload
+} from '@/components/object';
 import { ButtonMode } from '@/interfaces/common/enums';
 import { useBucketStore, useObjectStore } from '@/store';
 

--- a/frontend/src/components/object/ObjectProperties.vue
+++ b/frontend/src/components/object/ObjectProperties.vue
@@ -25,9 +25,9 @@ const props = defineProps({
   }
 });
 
-const bucket: Ref<Bucket | undefined > = ref(undefined);
-const createdBy = ref();
-const updatedBy = ref();
+const bucket: Ref<Bucket | undefined > = ref();
+const createdBy: Ref<string | undefined> = ref();
+const updatedBy: Ref<string | undefined> = ref();
 
 async function getBucketData() {
   // Get some associated bucket information
@@ -36,8 +36,8 @@ async function getBucketData() {
 
 async function getUserData() {
   await userStore.searchUsers({userId:[props.objectProperties?.createdBy, props.objectProperties?.updatedBy]});
-  createdBy.value = userSearch.value.find( x => x.userId === props.objectProperties?.createdBy );
-  updatedBy.value = userSearch.value.find( x => x.userId === props.objectProperties?.updatedBy );
+  createdBy.value = userSearch.value.find( x => x.userId === props.objectProperties?.createdBy )?.fullName;
+  updatedBy.value = userSearch.value.find( x => x.userId === props.objectProperties?.updatedBy )?.fullName;
 }
 
 onMounted(() => {
@@ -82,7 +82,7 @@ watch( props, async () => {
     <GridRow
       v-if="fullView"
       label="Created by"
-      :value="userSearch.find( x => x.userId === objectProperties?.createdBy)?.fullName"
+      :value="createdBy"
     />
     <GridRow
       v-if="fullView"
@@ -91,7 +91,7 @@ watch( props, async () => {
     />
     <GridRow
       label="Updated by"
-      :value="userSearch.find( x => x.userId === objectProperties?.updatedBy)?.fullName"
+      :value="updatedBy"
     />
     <GridRow
       label="Updated date"

--- a/frontend/src/components/object/ObjectProperties.vue
+++ b/frontend/src/components/object/ObjectProperties.vue
@@ -15,7 +15,7 @@ const userStore = useUserStore();
 const { userSearch } = storeToRefs(userStore);
 
 const props = defineProps({
-  objectProperties: {
+  objectInfo: {
     type: Object,
     default: undefined
   },
@@ -31,13 +31,13 @@ const updatedBy: Ref<string | undefined> = ref();
 
 async function getBucketData() {
   // Get some associated bucket information
-  bucket.value = await bucketStore.getBucketInfo(props.objectProperties?.bucketId);
+  bucket.value = await bucketStore.getBucketInfo(props.objectInfo?.bucketId);
 }
 
 async function getUserData() {
-  await userStore.searchUsers({userId:[props.objectProperties?.createdBy, props.objectProperties?.updatedBy]});
-  createdBy.value = userSearch.value.find( x => x.userId === props.objectProperties?.createdBy )?.fullName;
-  updatedBy.value = userSearch.value.find( x => x.userId === props.objectProperties?.updatedBy )?.fullName;
+  await userStore.searchUsers({userId:[props.objectInfo?.createdBy, props.objectInfo?.updatedBy]});
+  createdBy.value = userSearch.value.find( x => x.userId === props.objectInfo?.createdBy )?.fullName;
+  updatedBy.value = userSearch.value.find( x => x.userId === props.objectInfo?.updatedBy )?.fullName;
 }
 
 onMounted(() => {
@@ -45,9 +45,9 @@ onMounted(() => {
   getUserData();
 });
 
-watch( props, async () => {
-  await getBucketData();
-  await getUserData();
+watch( props, () => {
+  getBucketData();
+  getUserData();
 });
 
 </script>
@@ -62,7 +62,7 @@ watch( props, async () => {
 
     <GridRow
       label="Name"
-      :value="objectProperties?.name"
+      :value="objectInfo?.name"
     />
     <GridRow
       v-if="fullView"
@@ -73,11 +73,11 @@ watch( props, async () => {
     <GridRow
       v-if="fullView"
       label="Bucket ID"
-      :value="objectProperties?.bucketId"
+      :value="objectInfo?.bucketId"
     />
     <GridRow
       label="Object ID"
-      :value="objectProperties?.id"
+      :value="objectInfo?.id"
     />
     <GridRow
       v-if="fullView"
@@ -87,7 +87,7 @@ watch( props, async () => {
     <GridRow
       v-if="fullView"
       label="Creation date"
-      :value="formatDateLong(objectProperties?.createdAt)"
+      :value="formatDateLong(objectInfo?.createdAt)"
     />
     <GridRow
       label="Updated by"
@@ -95,7 +95,7 @@ watch( props, async () => {
     />
     <GridRow
       label="Updated date"
-      :value="formatDateLong(objectProperties?.updatedAt)"
+      :value="formatDateLong(objectInfo?.updatedAt)"
     />
   </div>
 </template>

--- a/frontend/src/components/object/ObjectProperties.vue
+++ b/frontend/src/components/object/ObjectProperties.vue
@@ -1,11 +1,53 @@
 <script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useBucketStore, useUserStore } from '@/store';
+import GridRow from '@/components/form/GridRow.vue';
+import { RouteNames } from '@/utils/constants';
 import { formatDateLong } from '@/utils/formatters';
 
-defineProps({
+import type { Ref } from 'vue';
+import type { Bucket } from '@/interfaces';
+
+const bucketStore = useBucketStore();
+const userStore = useUserStore();
+
+const { userSearch } = storeToRefs(userStore);
+
+const props = defineProps({
   objectProperties: {
     type: Object,
     default: undefined
+  },
+  fullView: {
+    type: Boolean,
+    default: true
   }
+});
+
+const bucket: Ref<Bucket | undefined > = ref(undefined);
+const createdBy = ref();
+const updatedBy = ref();
+
+async function getBucketData() {
+  // Get some associated bucket information
+  bucket.value = await bucketStore.getBucketInfo(props.objectProperties?.bucketId);
+}
+
+async function getUserData() {
+  await userStore.searchUsers({userId:[props.objectProperties?.createdBy, props.objectProperties?.updatedBy]});
+  createdBy.value = userSearch.value.find( x => x.userId === props.objectProperties?.createdBy );
+  updatedBy.value = userSearch.value.find( x => x.userId === props.objectProperties?.updatedBy );
+}
+
+onMounted(() => {
+  getBucketData();
+  getUserData();
+});
+
+watch( props, async () => {
+  await getBucketData();
+  await getUserData();
 });
 
 </script>
@@ -17,77 +59,43 @@ defineProps({
         Properties
       </h2>
     </div>
-    <div
-      v-if="objectProperties?.name"
-      class="col-3"
-    >
-      Name:
-    </div>
-    <div
-      v-if="objectProperties?.name"
-      class="col-9"
-    >
-      {{ objectProperties?.name }}
-    </div>
-    <div
-      v-if="objectProperties?.id"
-      class="col-3"
-    >
-      Object ID:
-    </div>
-    <div
-      v-if="objectProperties?.id"
-      class="col-9"
-    >
-      {{ objectProperties?.id }}
-    </div>
-    <div
-      v-if="objectProperties?.createdBy"
-      class="col-3"
-    >
-      Created by:
-    </div>
-    <div
-      v-if="objectProperties?.createdBy"
-      class="col-9"
-    >
-      {{ objectProperties?.createdBy }}
-    </div>
-    <div
-      v-if="objectProperties?.createdAt"
-      class="col-3"
-    >
-      Creation date:
-    </div>
-    <div
-      v-if="objectProperties?.createdAt"
-      class="col-9"
-    >
-      {{ formatDateLong(objectProperties?.createdAt) }}
-    </div>
-    <div
-      v-if="objectProperties?.updatedBy"
-      class="col-3"
-    >
-      Updated by:
-    </div>
-    <div
-      v-if="objectProperties?.updatedBy"
-      class="col-9"
-    >
-      {{ objectProperties?.updatedBy }}
-    </div>
-    <div
-      v-if="objectProperties?.updatedAt"
-      class="col-3"
-    >
-      Updated date:
-    </div>
-    <div
-      v-if="objectProperties?.updatedAt"
-      class="col-9"
-    >
-      {{ formatDateLong(objectProperties?.updatedAt) }}
-    </div>
+
+    <GridRow
+      label="Name"
+      :value="objectProperties?.name"
+    />
+    <GridRow
+      v-if="fullView"
+      label="Bucket"
+      :value="bucket?.bucketName"
+      :link="{ name: RouteNames.ListObjects, query: { bucketId: bucket?.bucketId } }"
+    />
+    <GridRow
+      v-if="fullView"
+      label="Bucket ID"
+      :value="objectProperties?.bucketId"
+    />
+    <GridRow
+      label="Object ID"
+      :value="objectProperties?.id"
+    />
+    <GridRow
+      v-if="fullView"
+      label="Created by"
+      :value="userSearch.find( x => x.userId === objectProperties?.createdBy)?.fullName"
+    />
+    <GridRow
+      v-if="fullView"
+      label="Creation date"
+      :value="formatDateLong(objectProperties?.createdAt)"
+    />
+    <GridRow
+      label="Updated by"
+      :value="userSearch.find( x => x.userId === objectProperties?.updatedBy)?.fullName"
+    />
+    <GridRow
+      label="Updated date"
+      :value="formatDateLong(objectProperties?.updatedAt)"
+    />
   </div>
 </template>

--- a/frontend/src/components/object/ObjectSidebar.vue
+++ b/frontend/src/components/object/ObjectSidebar.vue
@@ -42,7 +42,7 @@ const closeInfo = async () => {
   </div>
   <div class="pl-2">
     <ObjectProperties
-      :object-properties="displayInfo"
+      :object-info="displayInfo"
       :full-view="false"
     />
     <ObjectMetadata :object-metadata="displayInfo?.metadata" />

--- a/frontend/src/components/object/ObjectSidebar.vue
+++ b/frontend/src/components/object/ObjectSidebar.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { RouteNames } from '@/utils/constants';
-// PrimeVue
 import Button from 'primevue/button';
-// Other
-import ObjectAccess from '@/components/object/ObjectAccess.vue';
-import ObjectMetadata from '@/components/object/ObjectMetadata.vue';
-import ObjectProperties from '@/components/object/ObjectProperties.vue';
-import ObjectTag from '@/components/object/ObjectTag.vue';
+
+import {
+  ObjectMetadata,
+  ObjectProperties,
+  ObjectTag
+} from '@/components/object';
 
 defineProps({
   displayInfo: {

--- a/frontend/src/components/object/ObjectSidebar.vue
+++ b/frontend/src/components/object/ObjectSidebar.vue
@@ -41,8 +41,10 @@ const closeInfo = async () => {
     </div>
   </div>
   <div class="pl-2">
-    <ObjectProperties :object-properties="displayInfo" />
-    <ObjectAccess :object-access="displayInfo" />
+    <ObjectProperties
+      :object-properties="displayInfo"
+      :full-view="false"
+    />
     <ObjectMetadata :object-metadata="displayInfo?.metadata" />
     <ObjectTag :object-tag="displayInfo?.tag" />
     <div class="col-9">

--- a/frontend/src/components/object/ObjectTable.vue
+++ b/frontend/src/components/object/ObjectTable.vue
@@ -7,9 +7,11 @@ import Column from 'primevue/column';
 import DataTable from 'primevue/datatable';
 import Dialog from 'primevue/dialog';
 
-import DeleteObjectButton from '@/components/object/DeleteObjectButton.vue';
-import DownloadObjectButton from '@/components/object/DownloadObjectButton.vue';
-import ObjectPermission from '@/components/object/ObjectPermission.vue';
+import {
+  DeleteObjectButton,
+  DownloadObjectButton,
+  ObjectPermission
+} from '@/components/object';
 import { ButtonMode } from '@/interfaces/common/enums';
 import { useObjectStore, useUserStore } from '@/store';
 import { Permissions } from '@/utils/constants';

--- a/frontend/src/components/object/ObjectUpload.vue
+++ b/frontend/src/components/object/ObjectUpload.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
-// Vue
 import { ref } from 'vue';
 import { useRoute } from 'vue-router';
-// PrimeVue
 import { useToast } from 'primevue/usetoast';
 import Button from 'primevue/button';
 import FileUpload from 'primevue/fileupload';
-// State
-import { useObjectStore } from '@/store';
-// Component
+
 import ObjectUploadFile from '@/components/object/ObjectUploadFile.vue';
+import { useObjectStore } from '@/store';
 
 import type { Ref } from 'vue';
 

--- a/frontend/src/components/object/ObjectUploadFile.vue
+++ b/frontend/src/components/object/ObjectUploadFile.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-// PrimeVue
+import { filesize } from 'filesize';
 import Badge from 'primevue/badge';
 import Button from 'primevue/button';
-// Utils
-import { filesize } from 'filesize';
 
 defineProps({
   files: {

--- a/frontend/src/components/object/index.ts
+++ b/frontend/src/components/object/index.ts
@@ -1,0 +1,14 @@
+export { default as DeleteObjectButton } from './DeleteObjectButton.vue';
+export { default as DownloadObjectButton } from './DownloadObjectButton.vue';
+export { default as ObjectAccess } from './ObjectAccess.vue';
+export { default as ObjectFileDetails } from './ObjectFileDetails.vue';
+export { default as ObjectList } from './ObjectList.vue';
+export { default as ObjectMetadata } from './ObjectMetadata.vue';
+export { default as ObjectPermission } from './ObjectPermission.vue';
+export { default as ObjectPermissionAddUser } from './ObjectPermissionAddUser.vue';
+export { default as ObjectProperties } from './ObjectProperties.vue';
+export { default as ObjectSidebar } from './ObjectSidebar.vue';
+export { default as ObjectTable } from './ObjectTable.vue';
+export { default as ObjectTag } from './ObjectTag.vue';
+export { default as ObjectUpload } from './ObjectUpload.vue';
+export { default as ObjectUploadFile } from './ObjectUploadFile.vue';

--- a/frontend/src/interfaces/COMSObject.ts
+++ b/frontend/src/interfaces/COMSObject.ts
@@ -1,4 +1,4 @@
-import type { Metadata, Tagging } from '@/interfaces';
+import type { Metadata, Permission, Tagging } from '@/interfaces';
 
 export interface COMSObject {
   // Object columns
@@ -14,7 +14,9 @@ export interface COMSObject {
 
   // Additional
   metadata: Metadata;
+  permissions: Permission[];
   tag: Tagging;
+
 
   // Filled from metadata if available for easier reference
   name: string;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

- Adds bucket information to object properties screen
- Adds action buttons to object properties screen
- Sidebar object details no longer displays all the information
- Adds back the 'Manage by' information

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->