### PR TITLE
Add missing style on file details object permissions

### DIFF
--- a/frontend/src/components/object/ObjectFileDetails.vue
+++ b/frontend/src/components/object/ObjectFileDetails.vue
@@ -123,22 +123,20 @@ watch( [props, getObjects], () => {
     v-model:visible="permissionsVisible"
     :draggable="false"
     :modal="true"
-    class="permissions-modal"
+    class="bcbox-info-dialog permissions-modal"
   >
     <!-- eslint-enable vue/no-v-model-argument -->
     <template #header>
-      <div class="flex">
-        <font-awesome-icon
-          icon="fa-solid fa-users"
-          class="pr-3 pt-2"
-          style="font-size: 2rem"
-        />
-        <div>
-          <h1>Object Permissions</h1>
-          <h3>{{ permissionsObjectName }}</h3>
-        </div>
-      </div>
+      <font-awesome-icon
+        icon="fas fa-users"
+        fixed-width
+      />
+      <span class="p-dialog-title">Object Permissions</span>
     </template>
+
+    <h3 class="bcbox-info-dialog-subhead">
+      {{ permissionsObjectName }}
+    </h3>
 
     <ObjectPermission :object-id="permissionsObjectId" />
   </Dialog>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Missed setting the style on the File Details > Object Permissions dialog

We really should refactor this to a ObjectPermissionsButton component since it's used in 2 places, we don't need to be doing "hey here's the button, clicking the button does this, here's the dialog, the dialog contains this component" twice. But leaving that for the immediate term since I see tickets in progress about file permissions, and the file details page, so let's avoid possible merge conflict right now.

![image](https://user-images.githubusercontent.com/17445138/224444474-e0f72c1b-f78b-418f-bb42-13a93d2f585a.png)


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->