### PR TITLE
Wrap object and bucket name heading

### DIFF
--- a/frontend/src/assets/base.css
+++ b/frontend/src/assets/base.css
@@ -66,12 +66,7 @@ body {
   line-height: 1.6;
   font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
-  font-size: 15px;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-.p-datatable{
-  font-size: 15px;
 }

--- a/frontend/src/assets/base.css
+++ b/frontend/src/assets/base.css
@@ -71,3 +71,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+.p-datatable{
+  font-size: 15px;
+}

--- a/frontend/src/assets/main.scss
+++ b/frontend/src/assets/main.scss
@@ -29,7 +29,33 @@
   width: 800px;
 }
 
-// Info/settings dialog modals
+// -------- layout
+
+// details page / sidebar
+.details-grid {
+  h2 { margin-bottom: 1rem; }
+  .col-fixed { width: 150px; }  // label column
+  // make datatable look like grid
+  .p-datatable {
+    thead th{ padding-top: 0; }
+    td { padding: 0.5rem; }
+    th:first-child,
+    td:first-child { padding-left: 0; }
+  }
+}
+.details-value-column { width: 40rem; }
+.sidebar .details-value-column { width: 20rem; }
+// eof details page / sidebar
+
+// wrap text
+.wrap-block{
+  display: inline-block;
+  overflow-wrap: break-word;
+  width: 100%;
+}
+td .wrap-block{ width: inherit; }
+
+// --------- Info/settings dialog modals
 .bcbox-info-dialog {
   &.p-dialog {
     .p-dialog-header {
@@ -53,6 +79,7 @@
       font-weight: normal;
       margin-bottom: 1.5rem;
       padding-left: 3.1rem;
+      @extend .wrap-block;
     }
   }
 }

--- a/frontend/src/components/bucket/BucketSidebar.vue
+++ b/frontend/src/components/bucket/BucketSidebar.vue
@@ -11,7 +11,7 @@ import type { Bucket, BucketPermission } from '@/types';
 
 // Props
 type Props = {
-  sidebarInfo: Bucket
+  sidebarInfo: Bucket;
 };
 
 const props = withDefaults(defineProps<Props>(), {});
@@ -35,15 +35,25 @@ const closeSidebarInfo = async () => {
 };
 
 async function load() {
-  await permissionStore.fetchBucketPermissions({bucketId: props.sidebarInfo.bucketId});
+  await permissionStore.fetchBucketPermissions({
+    bucketId: props.sidebarInfo.bucketId,
+  });
 
-  const uniqueIds = [...new Set(getBucketPermissions.value
-    .filter( (x: BucketPermission) => x.bucketId === props.sidebarInfo.bucketId && x.permCode === Permissions.MANAGE )
-    .map( (x: BucketPermission) => x.userId) )];
+  const uniqueIds = [
+    ...new Set(
+      getBucketPermissions.value
+        .filter(
+          (x: BucketPermission) =>
+            x.bucketId === props.sidebarInfo.bucketId &&
+            x.permCode === Permissions.MANAGE
+        )
+        .map((x: BucketPermission) => x.userId)
+    ),
+  ];
 
-  if(uniqueIds.length) {
-    await userStore.fetchUsers({userId: uniqueIds} );
-    managedBy.value = userSearch.value.map( x => x.fullName ).join( ', ');
+  if (uniqueIds.length) {
+    await userStore.fetchUsers({ userId: uniqueIds });
+    managedBy.value = userSearch.value.map((x) => x.fullName).join(', ');
   }
 }
 
@@ -51,7 +61,7 @@ onBeforeMount(() => {
   load();
 });
 
-watch( props, () => {
+watch(props, () => {
   load();
 });
 </script>
@@ -74,33 +84,35 @@ watch( props, () => {
       </Button>
     </div>
   </div>
-  <div class="pl-2">
-    <div class="grid">
+
+  <div class="pl-2 sidebar">
+    <div class="grid details-grid grid-nogutter">
       <div class="col-12">
-        <h2>Properties</h2>
+        <h2 class="font-bold">Properties</h2>
       </div>
-      <div class="col-3">
-        Bucket Name:
+      <div class="grid overflow-hidden">
+        <div class="col-fixed">Bucket Name:</div>
+        <div class="col wrap-block w-6">
+          {{ props.sidebarInfo?.bucketName }}
+        </div>
       </div>
-      <div class="col-9">
-        {{ props.sidebarInfo?.bucketName }}
-      </div>
-      <div class="col-3">
-        Bucket ID:
-      </div>
-      <div class="col-9">
-        {{ props.sidebarInfo?.bucketId }}
+      <div class="grid">
+        <div class="col-fixed">Bucket ID:</div>
+        <div class="col">
+          {{ props.sidebarInfo?.bucketId }}
+        </div>
       </div>
     </div>
-    <div class="grid">
+
+    <div class="grid details-grid grid-nogutter">
       <div class="col-12">
-        <h2>Access</h2>
+        <h2 class="font-bold">Access</h2>
       </div>
-      <div class="col-3">
-        Managed by:
-      </div>
-      <div class="col-9">
-        {{ managedBy }}
+      <div class="grid">
+        <div class="col-fixed">Managed by:</div>
+        <div class="col">
+          {{ managedBy }}
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/components/bucket/BucketSidebar.vue
+++ b/frontend/src/components/bucket/BucketSidebar.vue
@@ -88,28 +88,37 @@ watch(props, () => {
   <div class="pl-2 sidebar">
     <div class="grid details-grid grid-nogutter">
       <div class="col-12">
-        <h2 class="font-bold">Properties</h2>
+        <h2 class="font-bold">
+          Properties
+        </h2>
       </div>
       <div class="grid overflow-hidden">
-        <div class="col-fixed">Bucket Name:</div>
+        <div class="col-fixed">
+          Bucket Name:
+        </div>
         <div class="col wrap-block w-6">
           {{ props.sidebarInfo?.bucketName }}
         </div>
       </div>
       <div class="grid">
-        <div class="col-fixed">Bucket ID:</div>
+        <div class="col-fixed">
+          Bucket ID:
+        </div>
         <div class="col">
           {{ props.sidebarInfo?.bucketId }}
         </div>
       </div>
     </div>
-
     <div class="grid details-grid grid-nogutter">
       <div class="col-12">
-        <h2 class="font-bold">Access</h2>
+        <h2 class="font-bold">
+          Access
+        </h2>
       </div>
       <div class="grid">
-        <div class="col-fixed">Managed by:</div>
+        <div class="col-fixed">
+          Managed by:
+        </div>
         <div class="col">
           {{ managedBy }}
         </div>

--- a/frontend/src/components/form/GridRow.vue
+++ b/frontend/src/components/form/GridRow.vue
@@ -13,26 +13,17 @@ const props = withDefaults(defineProps<Props>(), {
 </script>
 
 <template>
-  <div
-    v-if="props.value && props.label"
-    class="col-3"
-  >
-    {{ label }}:
-  </div>
-  <div
-    v-if="props.value && props.link"
-    class="col-9"
-  >
-    <router-link
-      :to="props.link"
-    >
-      {{ props.value }}
-    </router-link>
-  </div>
-  <div
-    v-if="props.value && !props.link"
-    class="col-9"
-  >
-    {{ props.value }}
+  <div class="col-12">
+    <div class="grid">
+      <div v-if="props.value && props.label" class="col-fixed">{{ label }}:</div>
+      <div v-if="props.value && props.link" class="col wrap-block w-9">
+        <router-link :to="props.link">
+          {{ props.value }}
+        </router-link>
+      </div>
+      <div v-if="props.value && !props.link" class="col wrap-block w-9">
+        {{ props.value }}
+      </div>
+    </div>
   </div>
 </template>

--- a/frontend/src/components/object/ObjectAccess.vue
+++ b/frontend/src/components/object/ObjectAccess.vue
@@ -46,17 +46,19 @@ watch( props, () => {
 </script>
 
 <template>
-  <div class="grid">
+  <div class="grid details-grid grid-nogutter mb-2">
     <div class="col-12">
       <h2 class="font-bold">
         Access
       </h2>
     </div>
-    <div class="col-3">
-      Managed by:
-    </div>
-    <div class="col-9">
-      {{ managedBy }}
+    <div class="grid">
+      <div class="col-fixed">
+        Managed by:
+      </div>
+      <div class="col">
+        {{ managedBy }}
+      </div>
     </div>
   </div>
 </template>

--- a/frontend/src/components/object/ObjectFileDetails.vue
+++ b/frontend/src/components/object/ObjectFileDetails.vue
@@ -122,7 +122,7 @@ watch( [props, getObjects], () => {
       </div>
     </div>
 
-    <div class="pl-2">
+    <div>
       <ObjectProperties
         :object-info-id="props.objectId"
         :full-view="true"
@@ -158,9 +158,3 @@ watch( [props, getObjects], () => {
     <ObjectPermission :object-id="permissionsObjectId" />
   </Dialog>
 </template>
-
-<style lang="scss" scoped>
-:deep(.grid) {
-  width: 33% !important;
-}
-</style>

--- a/frontend/src/components/object/ObjectMetadata.vue
+++ b/frontend/src/components/object/ObjectMetadata.vue
@@ -22,40 +22,50 @@ const objectMetadata: Ref<Metadata | undefined> = ref(undefined);
 
 // Actions
 async function load() {
-  objectMetadata.value = metadataStore.findMetadataByObjectId(props.objectInfoId);
+  objectMetadata.value = metadataStore.findMetadataByObjectId(
+    props.objectInfoId
+  );
 }
 
 onMounted(() => {
   load();
 });
 
-watch( props, () => {
+watch(props, () => {
   load();
 });
 </script>
 
 <template>
-  <div class="grid">
+  <div class="grid details-grid grid-nogutter mb-2">
     <div class="col-12">
-      <h2 class="font-bold">
-        Metadata
-      </h2>
+      <h2 class="font-bold">Metadata</h2>
     </div>
     <div>
       <DataTable
         v-if="objectMetadata"
         :value="objectMetadata.metadata"
-        striped-rows
         responsive-layout="scroll"
       >
-        <Column
-          field="key"
-          header="Key"
-        />
+        <Column field="key" header="Key">
+          <template #body="{ data }">
+            <div >
+              {{ data.key }}:
+            </div>
+          </template>
+        </Column>
+
         <Column
           field="value"
           header="Value"
-        />
+          class="overflow-hidden details-value-column"
+        >
+          <template #body="{ data }">
+            <div class="wrap-block">
+              {{ data.value }}
+            </div>
+          </template>
+        </Column>
       </DataTable>
     </div>
   </div>

--- a/frontend/src/components/object/ObjectProperties.vue
+++ b/frontend/src/components/object/ObjectProperties.vue
@@ -56,14 +56,15 @@ watch( props, () => {
 </script>
 
 <template>
-  <div class="grid">
-    <div class="col-12">
-      <h2 class="font-bold">
-        Properties
-      </h2>
+  <div class="grid details-grid grid-nogutter mb-2">
+      <div class="col-12">
+        <h2 class="font-bold">
+          Properties
+        </h2>
     </div>
 
     <GridRow
+      class=" overflow-hidden"
       label="Name"
       :value="objectMetadata?.metadata.find(x => x.key === 'name')?.value"
     />

--- a/frontend/src/components/object/ObjectSidebar.vue
+++ b/frontend/src/components/object/ObjectSidebar.vue
@@ -35,7 +35,7 @@ watch( props, () => {
 
 <template>
   <div class="flex justify-content-start">
-    <div class="flex col align-items-center pl-0">
+    <div class="flex col align-items-center">
       <font-awesome-icon
         icon="fa-solid fa-circle-info"
         style="font-size: 2rem"
@@ -52,7 +52,7 @@ watch( props, () => {
       />
     </div>
   </div>
-  <div class="pl-2">
+  <div class="pl-2 sidebar">
     <ObjectProperties
       :object-info-id="props.objectInfoId"
       :full-view="false"
@@ -61,7 +61,7 @@ watch( props, () => {
       :object-info-id="props.objectInfoId"
     />
     <ObjectTag :object-info-id="props.objectInfoId" />
-    <div class="col-9">
+    <div class="col-12 pl-0">
       <router-link
         v-slot="{ navigate }"
         custom

--- a/frontend/src/components/object/ObjectTag.vue
+++ b/frontend/src/components/object/ObjectTag.vue
@@ -39,7 +39,7 @@ watch( [props, getTagging], () => {
 <template>
   <div
     v-if="objectTagging?.tagset.length"
-    class="grid"
+    class="grid details-grid grid-nogutter mb-2"
   >
     <div class="col-12">
       <h2 class="font-bold">

--- a/frontend/src/components/object/ObjectUploadFile.vue
+++ b/frontend/src/components/object/ObjectUploadFile.vue
@@ -27,8 +27,8 @@ const props = withDefaults(defineProps<Props>(), {});
         :src="file.objectURL"
         width="50"
       />
-      <div>
-        <span>{{ file.name }}</span>
+      <div class="flex-grow-1 overflow-hidden">
+        <span class="wrap-block">{{ file.name }}</span>
         <div>
           <span class="pr-2">{{ filesize(file.size) }}</span>
           <Badge

--- a/frontend/src/views/list/ListObjectsView.vue
+++ b/frontend/src/views/list/ListObjectsView.vue
@@ -63,13 +63,13 @@ onMounted( () => {
     </h1>
     <h2
       v-if="bucket"
-      class="pb-3"
+      class="mb-3 flex overflow-hidden"
     >
       <font-awesome-icon
         icon="fa-solid fa-box-open"
-        class="mr-1"
+        class="mr-2 mt-2"
       />
-      {{ bucket.bucketName }}
+      <span class="wrap-block w-11">{{ bucket.bucketName }}</span>
     </h2>
     <ObjectList :bucket-id="props.bucketId" />
   </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

- fixes layout issues where object or bucket name overruns the screen and doesnt wrap to two lines.
- datatables have font-size 16px, set to 15px to match custom default set in body.
- I found some other css/display issues that we'll need to get fixed separately

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->