### PR TITLE
Home page: cap image size

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -29,7 +29,7 @@ const { getConfig } = storeToRefs(useConfigStore());
       <p class="text-xl text-center">
         This website uses the <a href="https://bcgov.github.io/common-service-showcase/services/coms.html">Common Object Management Service</a> so
         <a href="https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/id-services/idir">IDIR</a> and <a href="https://www.bceid.ca/">BCeID</a>
-        users can <br /> upload and share files with each other.
+        users can <br /> upload and share files.
       </p>
     </div>
     <div class="flex justify-content-center mb-5">
@@ -58,7 +58,7 @@ const { getConfig } = storeToRefs(useConfigStore());
         </div>
         <div class="flex align-items-left">
           <p class="text-xl">
-            With BCBox, you can use low-cost object storage for your files, <br />
+            With BCBox, you can use low-cost object storage for your files,
             images and documents.
           </p>
         </div>
@@ -82,7 +82,7 @@ const { getConfig } = storeToRefs(useConfigStore());
         <div class="flex align-items-left">
           <p class="text-xl">
             You can assign custom permissions to other users through IDIR or BCeID authentication.<br /><br />
-            You can also choose to share files with public links.
+            IDIR users can also choose to share files with public links.
             Contact your organization's privacy and security teams to see if this fits your intended use.
             Make sure you don't upload personal or private information without the consent of your Ministry
             Privacy Officer.
@@ -188,3 +188,9 @@ const { getConfig } = storeToRefs(useConfigStore());
     </div>
   </div>
 </template>
+
+<style scoped>
+img {
+  max-width: 100%;
+}
+</style>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Caps the images on the home page to the max width of their container to prevent spillage.
Minor wording adjustments.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->