### PR TITLE
Prevent removal of last manager when unticking READ

### DIFF
--- a/frontend/src/components/object/ObjectPermission.vue
+++ b/frontend/src/components/object/ObjectPermission.vue
@@ -50,14 +50,21 @@ const updateObjectPermission = (value: boolean, userId: string, permCode: string
   else {
     const managers = getMappedObjectToUserPermissions.value.filter( (x: UserPermissions) => x.manage );
 
+    const userPerms: UserPermissions = getMappedObjectToUserPermissions.value
+      .find( (x: UserPermissions) => x.userId === userId ) as UserPermissions;
+
+    // Due to 2-way binding we check if there are no managers left when MANAGE is unticked
+    const noManagers = permCode === Permissions.MANAGE && !managers.length;
+
+    // When READ is unticked check if they are the last remaining user with MANAGE
+    const lastManager = permCode === Permissions.READ && managers.length === 1 && userPerms.manage;
+
     // Disallow removable of final MANAGE permission
-    if( permCode === Permissions.MANAGE && !managers.length ) {
+    if( noManagers || lastManager ) {
       removeManageAlert.show();
 
-      // Set the value back as clicking will automatically change it
-      const perm: UserPermissions = getMappedObjectToUserPermissions.value
-        .find( (x: UserPermissions) => x.userId === userId ) as UserPermissions;
-      perm.manage = true;
+      if( permCode === Permissions.MANAGE ) userPerms.manage = true;
+      if( permCode === Permissions.READ ) userPerms.read = true;
     }
     else {
       permissionStore.deleteObjectPermission(props.objectId, userId, permCode);

--- a/frontend/src/components/object/ObjectPermission.vue
+++ b/frontend/src/components/object/ObjectPermission.vue
@@ -53,18 +53,18 @@ const updateObjectPermission = (value: boolean, userId: string, permCode: string
     const userPerms: UserPermissions = getMappedObjectToUserPermissions.value
       .find( (x: UserPermissions) => x.userId === userId ) as UserPermissions;
 
-    // Due to 2-way binding we check if there are no managers left when MANAGE is unticked
-    const noManagers = permCode === Permissions.MANAGE && !managers.length;
-
     // When READ is unticked check if they are the last remaining user with MANAGE
-    const lastManager = permCode === Permissions.READ && managers.length === 1 && userPerms.manage;
+    const lastManager = () => permCode === Permissions.READ && managers.length === 1 && userPerms.manage;
+
+    // Due to 2-way binding we check if there are no managers left when MANAGE is unticked
+    const noManagers = () => permCode === Permissions.MANAGE && !managers.length;
 
     // Disallow removable of final MANAGE permission
-    if( noManagers || lastManager ) {
+    if( lastManager() || noManagers() ) {
       removeManageAlert.show();
 
-      if( permCode === Permissions.MANAGE ) userPerms.manage = true;
       if( permCode === Permissions.READ ) userPerms.read = true;
+      if( permCode === Permissions.MANAGE ) userPerms.manage = true;
     }
     else {
       permissionStore.deleteObjectPermission(props.objectId, userId, permCode);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Prevents removal of the last manager of an object when unticking their READ permission.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->