### PR TITLE
BCBox v0.2.1 - Retarget metadata name to coms-name

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bcbox-app",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bcbox-app",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "api-problem": "^9.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcbox-app",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "",
   "author": "NR Common Service Showcase <NR.CommonServiceShowcase@gov.bc.ca>",

--- a/charts/bcbox/Chart.yaml
+++ b/charts/bcbox/Chart.yaml
@@ -3,7 +3,7 @@ name: bcbox
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: 0.0.7
 kubeVersion: ">= 1.13.0"
 description: A frontend UI for managing access control to S3 Objects
 # A chart can be either an 'application' or a 'library' chart.
@@ -37,6 +37,6 @@ maintainers:
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.0"
+appVersion: "0.2.1"
 deprecated: false
 annotations: {}

--- a/charts/bcbox/README.md
+++ b/charts/bcbox/README.md
@@ -1,6 +1,6 @@
 # bcbox
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.1](https://img.shields.io/badge/AppVersion-0.2.1-informational?style=flat-square)
 
 A frontend UI for managing access control to S3 Objects
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bcbox-frontend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bcbox-frontend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/bc-sans": "^1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcbox-frontend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "",
   "author": "NR Common Service Showcase <NR.CommonServiceShowcase@gov.bc.ca>",

--- a/frontend/src/components/object/ObjectFileDetails.vue
+++ b/frontend/src/components/object/ObjectFileDetails.vue
@@ -50,7 +50,7 @@ const toast = useToast();
 const showPermissions = async (objectId: string) => {
   permissionsVisible.value = true;
   permissionsObjectId.value = objectId;
-  permissionsObjectName.value = metadataStore.findValue(objectId, 'name') || '';
+  permissionsObjectName.value = metadataStore.findValue(objectId, 'coms-name') || '';
 };
 
 function onDeletedSuccess() {

--- a/frontend/src/components/object/ObjectProperties.vue
+++ b/frontend/src/components/object/ObjectProperties.vue
@@ -66,7 +66,7 @@ watch( props, () => {
     <GridRow
       class=" overflow-hidden"
       label="Name"
-      :value="objectMetadata?.metadata.find(x => x.key === 'name')?.value"
+      :value="objectMetadata?.metadata.find(x => x.key === 'coms-name')?.value"
     />
     <GridRow
       v-if="fullView"

--- a/frontend/src/components/object/ObjectTable.vue
+++ b/frontend/src/components/object/ObjectTable.vue
@@ -65,7 +65,7 @@ const showPermissions = async (objectId: string) => {
 
   permissionsVisible.value = true;
   permissionsObjectId.value = objectId;
-  permissionsObjectName.value = metadataStore.findValue(objectId, 'name') || '';
+  permissionsObjectName.value = metadataStore.findValue(objectId, 'coms-name') || '';
 };
 
 const togglePublic = async (objectId: string, isPublic: boolean) => {
@@ -98,7 +98,7 @@ watch( getObjects, async () => {
   await metadataStore.fetchMetadata({objectId: objIds});
 
   tableData.value = objs.map( (x: COMSObjectDataSource) => {
-    x.name = metadataStore.findValue(x.id, 'name');
+    x.name = metadataStore.findValue(x.id, 'coms-name');
     return x;
   });
 });

--- a/frontend/src/components/object/share/ShareObjectButton.vue
+++ b/frontend/src/components/object/share/ShareObjectButton.vue
@@ -58,7 +58,7 @@ onMounted( () => {
     </template>
 
     <h3 class="bcbox-info-dialog-subhead">
-      {{ metadataStore.findValue(id, 'name') }}
+      {{ metadataStore.findValue(id, 'coms-name') }}
     </h3>
 
     <ul class="mb-4">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This change is needed to align with COMS v0.4.2 where the metadata for the name field will now use the key `coms-name` instead of `name`.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->