### PR TITLE
Refactoring useToast - using config for timeout, reducing input param…

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,7 +5,7 @@ import { RouterView } from 'vue-router';
 import { AppLayout, Navbar, ProgressLoader } from '@/components/layout';
 import { ConfirmDialog, Toast }from '@/lib/primevue';
 import { useAppStore, useAuthStore, useConfigStore } from '@/store';
-import { error } from '@/lib/primevue/useToast';
+import { error } from '@/services/toastService';
 
 import type { Ref } from 'vue';
 
@@ -24,7 +24,7 @@ onBeforeMount(async () => {
 
 // Top level error handler
 onErrorCaptured((e: Error) => {
-  error('Error', e);
+  error('Error', e.message);
 });
 </script>
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,8 +3,9 @@ import { storeToRefs } from 'pinia';
 import { onBeforeMount, onErrorCaptured, ref } from 'vue';
 import { RouterView } from 'vue-router';
 import { AppLayout, Navbar, ProgressLoader } from '@/components/layout';
-import { ConfirmDialog, Toast, useToast }from '@/lib/primevue';
+import { ConfirmDialog, Toast }from '@/lib/primevue';
 import { useAppStore, useAuthStore, useConfigStore } from '@/store';
+import { error } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 
@@ -23,12 +24,7 @@ onBeforeMount(async () => {
 
 // Top level error handler
 onErrorCaptured((e: Error) => {
-  const toast = useToast();
-  toast.add({
-    severity: 'error',
-    summary: 'Error',
-    detail: e.message, life: 3000
-  });
+  error('Error', e);
 });
 </script>
 

--- a/frontend/src/components/bucket/BucketConfigForm.vue
+++ b/frontend/src/components/bucket/BucketConfigForm.vue
@@ -5,7 +5,8 @@ import { object, string } from 'yup';
 
 import Password from '@/components/form/Password.vue';
 import TextInput from '@/components/form/TextInput.vue';
-import { Button, useToast } from '@/lib/primevue';
+import { Button } from '@/lib/primevue';
+import { error, success } from '@/lib/primevue/useToast';
 import { useAuthStore, useBucketStore } from '@/store';
 import { differential } from '@/utils/utils';
 
@@ -57,7 +58,6 @@ const schema = object({
 });
 
 // Actions
-const toast = useToast();
 
 const onSubmit = async (values: any) => {
   try {
@@ -77,23 +77,9 @@ const onSubmit = async (values: any) => {
     await bucketStore.fetchBuckets({ userId: getUserId.value, objectPerms: true });
     emit('submit-bucket-config');
 
-    toast.add(
-      {
-        severity: 'success',
-        summary: 'Success',
-        detail: 'Bucket configuration successful',
-        life: 3000
-      }
-    );
-  } catch (error: any) {
-    toast.add(
-      {
-        severity: 'error',
-        summary: 'Bucket configuration was not successful',
-        detail: error,
-        life: 5000
-      }
-    );
+    success('Configuring bucket', 'Bucket configuration successful');
+  } catch (exception: any) {
+    error('Configuring bucket', exception);
   }
 };
 

--- a/frontend/src/components/bucket/BucketConfigForm.vue
+++ b/frontend/src/components/bucket/BucketConfigForm.vue
@@ -5,8 +5,8 @@ import { object, string } from 'yup';
 
 import Password from '@/components/form/Password.vue';
 import TextInput from '@/components/form/TextInput.vue';
+import { error, success } from '@/services/toastService';
 import { Button } from '@/lib/primevue';
-import { error, success } from '@/lib/primevue/useToast';
 import { useAuthStore, useBucketStore } from '@/store';
 import { differential } from '@/utils/utils';
 
@@ -78,8 +78,8 @@ const onSubmit = async (values: any) => {
     emit('submit-bucket-config');
 
     success('Configuring bucket', 'Bucket configuration successful');
-  } catch (exception: any) {
-    error('Configuring bucket', exception);
+  } catch (e: any) {
+    error('Configuring bucket', e);
   }
 };
 

--- a/frontend/src/components/form/CopyToClipboard.vue
+++ b/frontend/src/components/form/CopyToClipboard.vue
@@ -2,8 +2,8 @@
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 import { ButtonMode } from '@/utils/enums';
+import { info } from '@/services/toastService';
 import { Button } from '@/lib/primevue';
-import { info } from '@/lib/primevue/useToast';
 
 // Props
 type Props = {

--- a/frontend/src/components/form/CopyToClipboard.vue
+++ b/frontend/src/components/form/CopyToClipboard.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
-import { Button, useToast } from '@/lib/primevue';
 import { ButtonMode } from '@/utils/enums';
+import { Button } from '@/lib/primevue';
+import { info } from '@/lib/primevue/useToast';
 
 // Props
 type Props = {
@@ -16,16 +17,11 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 // Actions
-const toast = useToast();
 
 const copyToClipboard = () => {
   if( props.toCopy ) {
     navigator.clipboard.writeText(props.toCopy);
-    toast.add({
-      severity: 'info',
-      summary: 'Copied to clipboard',
-      life: 3000,
-    });
+    info('Copied to clipboard');
   }
 };
 </script>

--- a/frontend/src/components/object/DeleteObjectButton.vue
+++ b/frontend/src/components/object/DeleteObjectButton.vue
@@ -2,10 +2,10 @@
 import { ref } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
-import { Button, Dialog, useConfirm } from '@/lib/primevue';
+import { error } from '@/services/toastService';
 import { useObjectStore } from '@/store/objectStore';
+import { Button, Dialog, useConfirm } from '@/lib/primevue';
 import { ButtonMode } from '@/utils/enums';
-import { error } from '@/lib/primevue/useToast';
 
 // Props
 type Props = {
@@ -41,7 +41,7 @@ const confirmDelete = () => {
         try {
           await objectStore.deleteObjects(props.ids);
           emit('on-deleted-success');
-        } catch (e) {
+        } catch (e: any) {
           error('Deleting files', e);
           emit('on-deleted-error');
         }

--- a/frontend/src/components/object/DeleteObjectButton.vue
+++ b/frontend/src/components/object/DeleteObjectButton.vue
@@ -2,9 +2,10 @@
 import { ref } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
-import { Button, Dialog, useConfirm, useToast } from '@/lib/primevue';
+import { Button, Dialog, useConfirm } from '@/lib/primevue';
 import { useObjectStore } from '@/store/objectStore';
 import { ButtonMode } from '@/utils/enums';
+import { error } from '@/lib/primevue/useToast';
 
 // Props
 type Props = {
@@ -27,7 +28,6 @@ const displayNoFileDialog = ref(false);
 
 // Actions
 const confirm = useConfirm();
-const toast = useToast();
 
 const confirmDelete = () => {
   if (props.ids.length) {
@@ -41,8 +41,8 @@ const confirmDelete = () => {
         try {
           await objectStore.deleteObjects(props.ids);
           emit('on-deleted-success');
-        } catch (error) {
-          toast.add({ severity: 'error', summary: 'Error deleting one or more files', detail: error, life: 3000 });
+        } catch (e) {
+          error('Deleting files', e);
           emit('on-deleted-error');
         }
       },

--- a/frontend/src/components/object/ObjectFileDetails.vue
+++ b/frontend/src/components/object/ObjectFileDetails.vue
@@ -13,11 +13,11 @@ import {
   ObjectTag
 } from '@/components/object';
 import { ShareObjectButton } from '@/components/object/share';
+import { success } from '@/services/toastService';
 import { Button, Dialog } from '@/lib/primevue';
 import { useAuthStore, useMetadataStore, useObjectStore, usePermissionStore, useTagStore } from '@/store';
 import { Permissions, RouteNames } from '@/utils/constants';
 import { ButtonMode } from '@/utils/enums';
-import { success } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 import type { COMSObject } from '@/types';
@@ -54,7 +54,7 @@ const showPermissions = async (objectId: string) => {
 };
 
 function onDeletedSuccess() {
-  success('File deleting', 'File deteled')
+  success('Deleting file', 'File deteled');
   router.push({ name: RouteNames.LIST_OBJECTS, query: { bucketId: bucketId.value } });
 }
 

--- a/frontend/src/components/object/ObjectFileDetails.vue
+++ b/frontend/src/components/object/ObjectFileDetails.vue
@@ -13,10 +13,11 @@ import {
   ObjectTag
 } from '@/components/object';
 import { ShareObjectButton } from '@/components/object/share';
-import { Button, Dialog, useToast } from '@/lib/primevue';
+import { Button, Dialog } from '@/lib/primevue';
 import { useAuthStore, useMetadataStore, useObjectStore, usePermissionStore, useTagStore } from '@/store';
 import { Permissions, RouteNames } from '@/utils/constants';
 import { ButtonMode } from '@/utils/enums';
+import { success } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 import type { COMSObject } from '@/types';
@@ -45,7 +46,6 @@ const bucketId: Ref<string> = ref('');
 
 // Actions
 const router = useRouter();
-const toast = useToast();
 
 const showPermissions = async (objectId: string) => {
   permissionsVisible.value = true;
@@ -54,12 +54,7 @@ const showPermissions = async (objectId: string) => {
 };
 
 function onDeletedSuccess() {
-  toast.add({
-    severity: 'success',
-    summary: 'Success',
-    detail: 'File deleted',
-    life: 3000
-  });
+  success('File deleting', 'File deteled')
   router.push({ name: RouteNames.LIST_OBJECTS, query: { bucketId: bucketId.value } });
 }
 

--- a/frontend/src/components/object/ObjectList.vue
+++ b/frontend/src/components/object/ObjectList.vue
@@ -9,7 +9,7 @@ import {
   ObjectTable,
   ObjectUpload
 } from '@/components/object';
-import { Button, useToast } from '@/lib/primevue';
+import { Button } from '@/lib/primevue';
 import {
   useAuthStore,
   useBucketStore,
@@ -18,6 +18,7 @@ import {
 } from '@/store';
 import { Permissions } from '@/utils/constants';
 import { ButtonMode } from '@/utils/enums';
+import { success } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 
@@ -48,8 +49,6 @@ const selectedObjectIds = computed(() => {
 });
 
 // Actions
-const toast = useToast();
-
 const showObjectInfo = async (objectId: string | undefined) => {
   objectInfoId.value = objectId;
 };
@@ -76,12 +75,7 @@ const closeUpload = () => {
 // };
 
 function onDeletedSuccess() {
-  toast.add({
-    severity: 'success',
-    summary: 'Success',
-    detail: 'File(s) deleted',
-    life: 3000
-  });
+  success('File deleting', 'File deleted');
 }
 
 onMounted(async () => {

--- a/frontend/src/components/object/ObjectList.vue
+++ b/frontend/src/components/object/ObjectList.vue
@@ -9,6 +9,7 @@ import {
   ObjectTable,
   ObjectUpload
 } from '@/components/object';
+import { success } from '@/services/toastService';
 import { Button } from '@/lib/primevue';
 import {
   useAuthStore,
@@ -18,7 +19,6 @@ import {
 } from '@/store';
 import { Permissions } from '@/utils/constants';
 import { ButtonMode } from '@/utils/enums';
-import { success } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 
@@ -75,7 +75,7 @@ const closeUpload = () => {
 // };
 
 function onDeletedSuccess() {
-  success('File deleting', 'File deleted');
+  success('Deleting file', 'File deleted');
 }
 
 onMounted(async () => {

--- a/frontend/src/components/object/ObjectTable.vue
+++ b/frontend/src/components/object/ObjectTable.vue
@@ -8,12 +8,12 @@ import {
   ObjectPermission
 } from '@/components/object';
 import { ShareObjectButton } from '@/components/object/share';
+import { success } from '@/services/toastService';
 import { Button, Column, DataTable, Dialog, FilterMatchMode, InputText, InputSwitch } from '@/lib/primevue';
 import { useAuthStore, useAppStore, useMetadataStore, useObjectStore, usePermissionStore } from '@/store';
 import { Permissions } from '@/utils/constants';
 import { ButtonMode } from '@/utils/enums';
 import { formatDateLong } from '@/utils/formatters';
-import { info, success } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 import type { COMSObject } from '@/types';
@@ -72,7 +72,7 @@ const togglePublic = async (objectId: string, isPublic: boolean) => {
 };
 
 function onDeletedSuccess() {
-  success('File deleting', 'File deleted');
+  success('Deleting file', 'File deleted');
 }
 
 watch( getObjects, async () => {

--- a/frontend/src/components/object/ObjectTable.vue
+++ b/frontend/src/components/object/ObjectTable.vue
@@ -8,11 +8,12 @@ import {
   ObjectPermission
 } from '@/components/object';
 import { ShareObjectButton } from '@/components/object/share';
-import { Button, Column, DataTable, Dialog, FilterMatchMode, InputText, InputSwitch, useToast } from '@/lib/primevue';
+import { Button, Column, DataTable, Dialog, FilterMatchMode, InputText, InputSwitch } from '@/lib/primevue';
 import { useAuthStore, useAppStore, useMetadataStore, useObjectStore, usePermissionStore } from '@/store';
 import { Permissions } from '@/utils/constants';
 import { ButtonMode } from '@/utils/enums';
 import { formatDateLong } from '@/utils/formatters';
+import { info, success } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 import type { COMSObject } from '@/types';
@@ -50,8 +51,6 @@ const selectedObjects: Ref<Array<COMSObject>> = ref([]);
 const tableData: Ref<Array<COMSObjectDataSource>> = ref([]);
 
 // Actions
-const toast = useToast();
-
 const formatShortUuid = (uuid: string) => {
   return uuid?.slice(0,8) ?? uuid;
 };
@@ -73,12 +72,7 @@ const togglePublic = async (objectId: string, isPublic: boolean) => {
 };
 
 function onDeletedSuccess() {
-  toast.add({
-    severity: 'success',
-    summary: 'Success',
-    detail: 'File deleted',
-    life: 3000
-  });
+  success('File deleting', 'File deleted');
 }
 
 watch( getObjects, async () => {

--- a/frontend/src/components/object/ObjectUpload.vue
+++ b/frontend/src/components/object/ObjectUpload.vue
@@ -3,8 +3,9 @@ import { storeToRefs } from 'pinia';
 import { ref } from 'vue';
 
 import ObjectUploadFile from '@/components/object/ObjectUploadFile.vue';
-import { Button, FileUpload, useToast } from '@/lib/primevue';
+import { Button, FileUpload } from '@/lib/primevue';
 import { useAuthStore, useObjectStore } from '@/store';
+import { error } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 
@@ -28,7 +29,6 @@ const successfulFiles: Ref<Array<File>> = ref([]);
 const failedFiles: Ref<Array<File>> = ref([]);
 
 // Actions
-const toast = useToast();
 
 const onSelectedFiles = (event: any) => {
   pendingFiles.value = event.files;
@@ -49,8 +49,8 @@ const onUpload = async (event: any) => {
           // Infinite timeout for big files upload to avoid timeout error
           await objectStore.createObject(file, bucketId, { timeout: 0 });
           successfulFiles.value.push(file);
-        } catch (error) {
-          toast.add({ severity: 'error', summary: 'Error', detail: `Failed to upload file ${file.name}`, life: 3000 });
+        } catch (e) {
+          error('File uploading', e);
           failedFiles.value.push(file);
         }
       })
@@ -62,7 +62,7 @@ const onUpload = async (event: any) => {
     // Update object store
     await objectStore.fetchObjects({ bucketId: bucketId, userId: getUserId.value, bucketPerms: true });
   } else {
-    toast.add({ severity: 'error', summary: 'Error', detail: 'Failed to acquire bucket ID', life: 3000 });
+    error('File uploading', 'Failed to acquire bucket ID');
   }
 };
 

--- a/frontend/src/components/object/ObjectUpload.vue
+++ b/frontend/src/components/object/ObjectUpload.vue
@@ -5,7 +5,7 @@ import { ref } from 'vue';
 import ObjectUploadFile from '@/components/object/ObjectUploadFile.vue';
 import { Button, FileUpload } from '@/lib/primevue';
 import { useAuthStore, useObjectStore } from '@/store';
-import { error } from '@/lib/primevue/useToast';
+import { error } from '@/services/toastService';
 
 import type { Ref } from 'vue';
 
@@ -49,8 +49,8 @@ const onUpload = async (event: any) => {
           // Infinite timeout for big files upload to avoid timeout error
           await objectStore.createObject(file, bucketId, { timeout: 0 });
           successfulFiles.value.push(file);
-        } catch (e) {
-          error('File uploading', e);
+        } catch (e: any) {
+          error('Uploading file', e);
           failedFiles.value.push(file);
         }
       })
@@ -62,7 +62,7 @@ const onUpload = async (event: any) => {
     // Update object store
     await objectStore.fetchObjects({ bucketId: bucketId, userId: getUserId.value, bucketPerms: true });
   } else {
-    error('File uploading', 'Failed to acquire bucket ID');
+    error('Uploading file', 'Failed to acquire bucket ID');
   }
 };
 

--- a/frontend/src/components/object/share/ShareLinkContent.vue
+++ b/frontend/src/components/object/share/ShareLinkContent.vue
@@ -2,9 +2,8 @@
 import QrcodeVue from 'qrcode.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
-import { Button, InputText, useToast } from '@/lib/primevue';
-
-const toast = useToast();
+import { Button, InputText } from '@/lib/primevue';
+import { info } from '@/lib/primevue/useToast';
 
 // Props
 type Props = {
@@ -17,11 +16,7 @@ const props = withDefaults(defineProps<Props>(), {});
 // Actions
 const copyLinkToClipboard = () => {
   navigator.clipboard.writeText(props.shareLink);
-  toast.add({
-    severity: 'info',
-    summary: 'Share Link copied to clipboard',
-    life: 3000,
-  });
+  info('Share Link copied to clipboard');
 };
 </script>
 

--- a/frontend/src/components/object/share/ShareLinkContent.vue
+++ b/frontend/src/components/object/share/ShareLinkContent.vue
@@ -2,8 +2,8 @@
 import QrcodeVue from 'qrcode.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
+import { info } from '@/services/toastService';
 import { Button, InputText } from '@/lib/primevue';
-import { info } from '@/lib/primevue/useToast';
 
 // Props
 type Props = {
@@ -16,7 +16,7 @@ const props = withDefaults(defineProps<Props>(), {});
 // Actions
 const copyLinkToClipboard = () => {
   navigator.clipboard.writeText(props.shareLink);
-  info('Share Link copied to clipboard');
+  info('Share link copied to clipboard');
 };
 </script>
 

--- a/frontend/src/lib/primevue/index.ts
+++ b/frontend/src/lib/primevue/index.ts
@@ -22,5 +22,3 @@ export { default as Toast } from 'primevue/toast';
 export { default as Toolbar } from 'primevue/toolbar';
 
 export { useConfirm } from 'primevue/useconfirm';
-
-export { useToast } from './useToast';

--- a/frontend/src/lib/primevue/useToast.ts
+++ b/frontend/src/lib/primevue/useToast.ts
@@ -1,14 +1,34 @@
 import { useToast as useToastPrimevue } from 'primevue/usetoast';
 
+import { app } from '@/main';
+import { ConfigService } from '@/services/index';
 import type { ToastMessageOptions } from 'primevue/toast';
 
-export const useToast = () => {
-  const toast = useToastPrimevue();
+export function success(title: string, msg: any, options: ToastMessageOptions = {}): void {
+  app.config.globalProperties.$toast.add({
+    severity: 'success',
+    summary: title,
+    detail: msg,
+    life: new ConfigService().getConfig().toast.successTimeout,
+    ...options
+  });
+};
 
-  const add = (options: ToastMessageOptions = {}) => {
-    const { severity = 'error', summary = 'Unable to load data.', detail = '', life = 5000 } = options;
-    toast.add({ severity: severity, summary: summary, detail: detail, life: life });
-  };
+export function info(msg: any, options: ToastMessageOptions = {}): void {
+  app.config.globalProperties.$toast.add({
+    severity: 'info',
+    detail: msg,
+    life: new ConfigService().getConfig().toast.successTimeout,
+    ...options
+  });
+};
 
-  return { add };
+export const error = (title: string, msg: any, options: ToastMessageOptions = {}) => {
+  app.config.globalProperties.$toast.add({
+    severity: 'error',
+    summary: title,
+    detail: msg,
+    life: new ConfigService().getConfig().toast.successTimeout,
+    ...options
+  });
 };

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -20,6 +20,8 @@ import 'primeicons/primeicons.css';
 import 'primeflex/primeflex.css';
 import '@/assets/main.scss';
 
+export const app = createApp(App);
+
 /**
  * @function initializeApp
  * Initializes and mounts the Vue instance
@@ -27,7 +29,6 @@ import '@/assets/main.scss';
 function initializeApp(): void {
   library.add(fas);
 
-  const app = createApp(App);
   const pinia = createPinia();
   pinia.use(createPersistedState({
     key: id => `bcbox.${id}`

--- a/frontend/src/services/toastService.ts
+++ b/frontend/src/services/toastService.ts
@@ -1,20 +1,19 @@
-import { useToast as useToastPrimevue } from 'primevue/usetoast';
-
-import { app } from '@/main';
-import { ConfigService } from '@/services/index';
 import type { ToastMessageOptions } from 'primevue/toast';
 
-export function success(title: string, msg: any, options: ToastMessageOptions = {}): void {
+import { ConfigService } from '@/services/index';
+import { app } from '@/main';
+
+export const error = (title: string, msg: string, options: ToastMessageOptions = {}) => {
   app.config.globalProperties.$toast.add({
-    severity: 'success',
-    summary: title,
+    severity: 'error',
+    summary: 'Error:' + ' ' + title,
     detail: msg,
     life: new ConfigService().getConfig().toast.successTimeout,
     ...options
   });
 };
 
-export function info(msg: any, options: ToastMessageOptions = {}): void {
+export function info(msg: string, options: ToastMessageOptions = {}): void {
   app.config.globalProperties.$toast.add({
     severity: 'info',
     detail: msg,
@@ -23,10 +22,10 @@ export function info(msg: any, options: ToastMessageOptions = {}): void {
   });
 };
 
-export const error = (title: string, msg: any, options: ToastMessageOptions = {}) => {
+export function success(title: string, msg: string, options: ToastMessageOptions = {}): void {
   app.config.globalProperties.$toast.add({
-    severity: 'error',
-    summary: title,
+    severity: 'success',
+    summary: 'Sucess:' + ' ' + title,
     detail: msg,
     life: new ConfigService().getConfig().toast.successTimeout,
     ...options

--- a/frontend/src/store/bucketStore.ts
+++ b/frontend/src/store/bucketStore.ts
@@ -1,10 +1,10 @@
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 
-import { useToast } from '@/lib/primevue';
 import { bucketService } from '@/services';
 import { useAppStore, usePermissionStore } from '@/store';
 import { partition } from '@/utils/utils';
+import { error } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 import type { Bucket, BucketSearchPermissionsOptions } from '@/types';
@@ -14,7 +14,6 @@ export type BucketStoreState = {
 }
 
 export const useBucketStore = defineStore('bucket', () => {
-  const toast = useToast();
 
   // Store
   const appStore = useAppStore();
@@ -72,8 +71,8 @@ export const useBucketStore = defineStore('bucket', () => {
         }
       }
     }
-    catch (error) {
-      toast.add({ severity: 'error', summary: 'Error fetching buckets', detail: error, life: 3000 });
+    catch (e) {
+      error('Fetching buckets', e);
     }
     finally {
       appStore.endIndeterminateLoading();

--- a/frontend/src/store/bucketStore.ts
+++ b/frontend/src/store/bucketStore.ts
@@ -3,8 +3,8 @@ import { computed, ref } from 'vue';
 
 import { bucketService } from '@/services';
 import { useAppStore, usePermissionStore } from '@/store';
+import { error } from '@/services/toastService';
 import { partition } from '@/utils/utils';
-import { error } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 import type { Bucket, BucketSearchPermissionsOptions } from '@/types';
@@ -71,7 +71,7 @@ export const useBucketStore = defineStore('bucket', () => {
         }
       }
     }
-    catch (e) {
+    catch (e: any) {
       error('Fetching buckets', e);
     }
     finally {

--- a/frontend/src/store/metadataStore.ts
+++ b/frontend/src/store/metadataStore.ts
@@ -4,7 +4,7 @@ import { computed, ref } from 'vue';
 import { objectService } from '@/services';
 import { useAppStore } from '@/store';
 import { partition } from '@/utils/utils';
-import { error } from '@/lib/primevue/useToast';
+import { error } from '@/services/toastService';
 
 import type { Ref } from 'vue';
 import type { GetMetadataOptions, Metadata } from '@/types';
@@ -45,7 +45,7 @@ export const useMetadataStore = defineStore('metadata', () => {
       // Merge and assign
       state.metadata.value = difference.concat(response);
     }
-    catch (e) {
+    catch (e: any) {
       error('Fetching metadata', e);
     }
     finally {

--- a/frontend/src/store/metadataStore.ts
+++ b/frontend/src/store/metadataStore.ts
@@ -1,10 +1,10 @@
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 
-import { useToast } from '@/lib/primevue';
 import { objectService } from '@/services';
 import { useAppStore } from '@/store';
 import { partition } from '@/utils/utils';
+import { error } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 import type { GetMetadataOptions, Metadata } from '@/types';
@@ -15,7 +15,6 @@ export type MetadataStoreState = {
 
 export const useMetadataStore = defineStore('metadata', () => {
   const appStore = useAppStore();
-  const toast = useToast();
 
   // State
   const state: MetadataStoreState = {
@@ -46,8 +45,8 @@ export const useMetadataStore = defineStore('metadata', () => {
       // Merge and assign
       state.metadata.value = difference.concat(response);
     }
-    catch (error) {
-      toast.add({ severity: 'error', summary: 'Error fetching metadata', detail: error, life: 3000 });
+    catch (e) {
+      error('Fetching metadata', e);
     }
     finally {
       appStore.endIndeterminateLoading();

--- a/frontend/src/store/objectStore.ts
+++ b/frontend/src/store/objectStore.ts
@@ -4,7 +4,7 @@ import { computed, ref } from 'vue';
 import { objectService } from '@/services';
 import { useAppStore, useAuthStore, usePermissionStore } from '@/store';
 import { partition } from '@/utils/utils';
-import { error } from '@/lib/primevue/useToast';
+import { error } from '@/services/toastService';
 
 import type { AxiosRequestConfig } from 'axios';
 import type { Ref } from 'vue';
@@ -40,7 +40,7 @@ export const useObjectStore = defineStore('object', () => {
       appStore.beginIndeterminateLoading();
       await objectService.createObject(object, bucketId, axiosOptions);
     }
-    catch (e) {
+    catch (e: any) {
       error('Creating object', e);
     }
     finally {
@@ -59,8 +59,8 @@ export const useObjectStore = defineStore('object', () => {
         })
       );
     }
-    catch (e) {
-      error('Object deleting', e);
+    catch (e: any) {
+      error('Deleting object', e);
     }
     finally {
       fetchObjects({ bucketId: bucketId, userId: getUserId.value, bucketPerms: true });
@@ -73,7 +73,7 @@ export const useObjectStore = defineStore('object', () => {
       appStore.beginIndeterminateLoading();
       await objectService.getObject(objectId, versionId);
     }
-    catch (e) {
+    catch (e: any) {
       error('Downloading object', e);
     }
     finally {
@@ -121,7 +121,7 @@ export const useObjectStore = defineStore('object', () => {
         }
       }
     }
-    catch (e) {
+    catch (e: any) {
       error('Fetching objects', e);
     }
     finally {
@@ -140,8 +140,8 @@ export const useObjectStore = defineStore('object', () => {
       // Return full response as data will always be No Content
       return (await objectService.headObject(objectId));
     }
-    catch (e) {
-      error('Head fetching', e);
+    catch (e: any) {
+      error('Fetching head', e);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -157,7 +157,7 @@ export const useObjectStore = defineStore('object', () => {
       appStore.beginIndeterminateLoading();
       await objectService.togglePublic(objectId, isPublic);
     }
-    catch (e) {
+    catch (e: any) {
       error('Changing public state', e);
     }
     finally {

--- a/frontend/src/store/objectStore.ts
+++ b/frontend/src/store/objectStore.ts
@@ -1,10 +1,10 @@
 import { defineStore, storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 
-import { useToast } from '@/lib/primevue';
 import { objectService } from '@/services';
 import { useAppStore, useAuthStore, usePermissionStore } from '@/store';
 import { partition } from '@/utils/utils';
+import { error } from '@/lib/primevue/useToast';
 
 import type { AxiosRequestConfig } from 'axios';
 import type { Ref } from 'vue';
@@ -16,7 +16,6 @@ export type ObjectStoreState = {
 }
 
 export const useObjectStore = defineStore('object', () => {
-  const toast = useToast();
 
   // Store
   const appStore = useAppStore();
@@ -41,8 +40,8 @@ export const useObjectStore = defineStore('object', () => {
       appStore.beginIndeterminateLoading();
       await objectService.createObject(object, bucketId, axiosOptions);
     }
-    catch (error) {
-      toast.add({ severity: 'error', summary: 'Error creating object', detail: error, life: 3000 });
+    catch (e) {
+      error('Creating object', e);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -60,8 +59,8 @@ export const useObjectStore = defineStore('object', () => {
         })
       );
     }
-    catch (error) {
-      toast.add({ severity: 'error', summary: 'Error deleting object', detail: error, life: 3000 });
+    catch (e) {
+      error('Object deleting', e);
     }
     finally {
       fetchObjects({ bucketId: bucketId, userId: getUserId.value, bucketPerms: true });
@@ -74,8 +73,8 @@ export const useObjectStore = defineStore('object', () => {
       appStore.beginIndeterminateLoading();
       await objectService.getObject(objectId, versionId);
     }
-    catch (error) {
-      toast.add({ severity: 'error', summary: 'Error downloading object', detail: error, life: 3000 });
+    catch (e) {
+      error('Downloading object', e);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -122,8 +121,8 @@ export const useObjectStore = defineStore('object', () => {
         }
       }
     }
-    catch (error) {
-      toast.add({ severity: 'error', summary: 'Error fetching objects', detail: error, life: 3000 });
+    catch (e) {
+      error('Fetching objects', e);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -141,8 +140,8 @@ export const useObjectStore = defineStore('object', () => {
       // Return full response as data will always be No Content
       return (await objectService.headObject(objectId));
     }
-    catch (error) {
-      toast.add({ severity: 'error', summary: 'Error fetching head', detail: error, life: 3000 });
+    catch (e) {
+      error('Head fetching', e);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -158,8 +157,8 @@ export const useObjectStore = defineStore('object', () => {
       appStore.beginIndeterminateLoading();
       await objectService.togglePublic(objectId, isPublic);
     }
-    catch (error) {
-      toast.add({ severity: 'error', summary: 'Error changing public state', detail: error, life: 3000 });
+    catch (e) {
+      error('Changing public state', e);
     }
     finally {
       appStore.endIndeterminateLoading();

--- a/frontend/src/store/permissionStore.ts
+++ b/frontend/src/store/permissionStore.ts
@@ -1,7 +1,7 @@
 import { defineStore, storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 
-import { useToast } from '@/lib/primevue';
+import { error as toastError } from '@/lib/primevue/useToast';
 import { permissionService, userService } from '@/services';
 import { useAppStore, useAuthStore, useConfigStore } from '@/store';
 import { Permissions } from '@/utils/constants';
@@ -32,7 +32,6 @@ export const usePermissionStore = defineStore('permission', () => {
   const appStore = useAppStore();
   const { getProfile } = storeToRefs(useAuthStore());
   const { getConfig } = storeToRefs(useConfigStore());
-  const toast = useToast();
 
   // State
   const state: PermissionStoreState = {
@@ -59,7 +58,7 @@ export const usePermissionStore = defineStore('permission', () => {
       await permissionService.bucketAddPermissions(bucketId, [{ userId, permCode }]);
     }
     catch (error) {
-      toast.add({ severity: 'error', summary: 'Error adding bucket permission', detail: error, life: 3000 });
+      toastError('Adding bucket permission', error);
     }
     finally {
       await fetchBucketPermissions();
@@ -73,7 +72,7 @@ export const usePermissionStore = defineStore('permission', () => {
       getters.getMappedBucketToUserPermissions.value.push(user);
     }
     catch (error) {
-      toast.add({ severity: 'error', summary: 'Error adding bucket user', detail: error, life: 3000 });
+      toastError('Adding bucket user', error);
     }
   }
 
@@ -88,7 +87,7 @@ export const usePermissionStore = defineStore('permission', () => {
       }
     }
     catch (error) {
-      toast.add({ severity: 'error', summary: 'Error adding object permission', detail: error, life: 3000 });
+      toastError('Adding object permission', error);
     }
     finally {
       await fetchObjectPermissions();
@@ -102,7 +101,7 @@ export const usePermissionStore = defineStore('permission', () => {
       getters.getMappedObjectToUserPermissions.value.push(user);
     }
     catch (error) {
-      toast.add({ severity: 'error', summary: 'Error adding object user', detail: error, life: 3000 });
+      toastError('Adding object user', error);
     }
   }
 
@@ -112,7 +111,7 @@ export const usePermissionStore = defineStore('permission', () => {
       await permissionService.bucketDeletePermission(bucketId, { userId, permCode });
     }
     catch (error) {
-      toast.add({ severity: 'error', summary: 'Error deleting bucket permission', detail: error, life: 3000 });
+      toastError('Deleting bucket permission', error);
     }
     finally {
       await fetchBucketPermissions();
@@ -132,7 +131,7 @@ export const usePermissionStore = defineStore('permission', () => {
       }
     }
     catch (error) {
-      toast.add({ severity: 'error', summary: 'Error deleting object permission', detail: error, life: 3000 });
+      toastError('Deleting object permission', error);
     }
     finally {
       await fetchObjectPermissions();
@@ -162,7 +161,7 @@ export const usePermissionStore = defineStore('permission', () => {
       return response;
     }
     catch (error) {
-      toast.add({ severity: 'error', summary: 'Error fetching bucket permissions', detail: error, life: 3000 });
+      toastError('Fetching bucket permissions', error);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -193,7 +192,7 @@ export const usePermissionStore = defineStore('permission', () => {
       return response;
     }
     catch (error) {
-      toast.add({ severity: 'error', summary: 'Error fetching object permissions', detail: error, life: 3000 });
+      toastError('Fetching object permissions', error);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -253,12 +252,7 @@ export const usePermissionStore = defineStore('permission', () => {
       state.mappedBucketToUserPermissions.value = userPermissions;
     }
     catch (error) {
-      toast.add({
-        severity: 'error',
-        summary: 'Error mapping bucket permissions to user permissions',
-        detail: error,
-        life: 3000
-      });
+      toastError('Mapping bucket permissions to user permissions',error);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -296,12 +290,7 @@ export const usePermissionStore = defineStore('permission', () => {
       state.mappedObjectToUserPermissions.value = userPermissions;
     }
     catch (error) {
-      toast.add({
-        severity: 'error',
-        summary: 'Error mapping object permissions to user permissions',
-        detail: error,
-        life: 3000
-      });
+      toastError('Mapping object permissions to user permissions',error);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -316,7 +305,7 @@ export const usePermissionStore = defineStore('permission', () => {
       }
     }
     catch (error) {
-      toast.add({ severity: 'error', summary: 'Error removing bucket user', detail: error, life: 3000 });
+      toastError('Removing bucket user', error);
     }
     finally {
       await fetchBucketPermissions();
@@ -337,7 +326,7 @@ export const usePermissionStore = defineStore('permission', () => {
       }
     }
     catch (error) {
-      toast.add({ severity: 'error', summary: 'Error removing object user', detail: error, life: 3000 });
+      toastError('Removing object user', error);
     }
     finally {
       await fetchObjectPermissions();

--- a/frontend/src/store/permissionStore.ts
+++ b/frontend/src/store/permissionStore.ts
@@ -1,7 +1,7 @@
 import { defineStore, storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 
-import { error as toastError } from '@/lib/primevue/useToast';
+import { error } from '@/services/toastService';
 import { permissionService, userService } from '@/services';
 import { useAppStore, useAuthStore, useConfigStore } from '@/store';
 import { Permissions } from '@/utils/constants';
@@ -57,8 +57,8 @@ export const usePermissionStore = defineStore('permission', () => {
       appStore.beginIndeterminateLoading();
       await permissionService.bucketAddPermissions(bucketId, [{ userId, permCode }]);
     }
-    catch (error) {
-      toastError('Adding bucket permission', error);
+    catch (e: any) {
+      error('Adding bucket permission', e);
     }
     finally {
       await fetchBucketPermissions();
@@ -71,8 +71,8 @@ export const usePermissionStore = defineStore('permission', () => {
     try {
       getters.getMappedBucketToUserPermissions.value.push(user);
     }
-    catch (error) {
-      toastError('Adding bucket user', error);
+    catch (e: any) {
+      error('Adding bucket user', e);
     }
   }
 
@@ -86,8 +86,8 @@ export const usePermissionStore = defineStore('permission', () => {
         await permissionService.objectAddPermissions(objectId, [{ userId, permCode: Permissions.READ }]);
       }
     }
-    catch (error) {
-      toastError('Adding object permission', error);
+    catch (e: any) {
+      error('Adding object permission', e);
     }
     finally {
       await fetchObjectPermissions();
@@ -100,8 +100,8 @@ export const usePermissionStore = defineStore('permission', () => {
     try {
       getters.getMappedObjectToUserPermissions.value.push(user);
     }
-    catch (error) {
-      toastError('Adding object user', error);
+    catch (e: any) {
+      error('Adding object user', e);
     }
   }
 
@@ -110,8 +110,8 @@ export const usePermissionStore = defineStore('permission', () => {
       appStore.beginIndeterminateLoading();
       await permissionService.bucketDeletePermission(bucketId, { userId, permCode });
     }
-    catch (error) {
-      toastError('Deleting bucket permission', error);
+    catch (e: any) {
+      error('Deleting bucket permission', e);
     }
     finally {
       await fetchBucketPermissions();
@@ -130,8 +130,8 @@ export const usePermissionStore = defineStore('permission', () => {
         await permissionService.objectDeletePermission(objectId, { userId, permCode: forceToggleOnRead });
       }
     }
-    catch (error) {
-      toastError('Deleting object permission', error);
+    catch (e: any) {
+      error('Deleting object permission', e);
     }
     finally {
       await fetchObjectPermissions();
@@ -160,8 +160,8 @@ export const usePermissionStore = defineStore('permission', () => {
       // Pass response back so bucketStore can handle bucketPerms=true correctly
       return response;
     }
-    catch (error) {
-      toastError('Fetching bucket permissions', error);
+    catch (e: any) {
+      error('Fetching bucket permissions', e);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -191,8 +191,8 @@ export const usePermissionStore = defineStore('permission', () => {
       // Pass response back so objectStore can handle objectPerms=true correctly
       return response;
     }
-    catch (error) {
-      toastError('Fetching object permissions', error);
+    catch (e: any) {
+      error('Fetching object permissions', e);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -251,8 +251,8 @@ export const usePermissionStore = defineStore('permission', () => {
 
       state.mappedBucketToUserPermissions.value = userPermissions;
     }
-    catch (error) {
-      toastError('Mapping bucket permissions to user permissions',error);
+    catch (e: any) {
+      error('Mapping bucket permissions to user permissions', e);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -289,8 +289,8 @@ export const usePermissionStore = defineStore('permission', () => {
 
       state.mappedObjectToUserPermissions.value = userPermissions;
     }
-    catch (error) {
-      toastError('Mapping object permissions to user permissions',error);
+    catch (e: any) {
+      error('Mapping object permissions to user permissions', e);
     }
     finally {
       appStore.endIndeterminateLoading();
@@ -304,8 +304,8 @@ export const usePermissionStore = defineStore('permission', () => {
         await permissionService.bucketDeletePermission(bucketId, { userId, permCode: value });
       }
     }
-    catch (error) {
-      toastError('Removing bucket user', error);
+    catch (e: any) {
+      error('Removing bucket user', e);
     }
     finally {
       await fetchBucketPermissions();
@@ -325,8 +325,8 @@ export const usePermissionStore = defineStore('permission', () => {
         });
       }
     }
-    catch (error) {
-      toastError('Removing object user', error);
+    catch (e: any) {
+      error('Removing object user', e);
     }
     finally {
       await fetchObjectPermissions();

--- a/frontend/src/store/tagStore.ts
+++ b/frontend/src/store/tagStore.ts
@@ -4,7 +4,7 @@ import { computed, ref } from 'vue';
 import { objectService } from '@/services';
 import { useAppStore } from '@/store';
 import { partition } from '@/utils/utils';
-import { error } from '@/lib/primevue/useToast';
+import { error } from '@/services/toastService';
 
 import type { Ref } from 'vue';
 import type { GetObjectTaggingOptions, Tagging } from '@/types';
@@ -45,7 +45,7 @@ export const useTagStore = defineStore('tag', () => {
       // Merge and assign
       state.tagging.value = difference.concat(response);
     }
-    catch (e) {
+    catch (e: any) {
       error('Fetching tags', e);
     }
     finally {

--- a/frontend/src/store/tagStore.ts
+++ b/frontend/src/store/tagStore.ts
@@ -1,10 +1,10 @@
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 
-import { useToast } from '@/lib/primevue';
 import { objectService } from '@/services';
 import { useAppStore } from '@/store';
 import { partition } from '@/utils/utils';
+import { error } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 import type { GetObjectTaggingOptions, Tagging } from '@/types';
@@ -15,7 +15,6 @@ export type TagStoreState = {
 
 export const useTagStore = defineStore('tag', () => {
   const appStore = useAppStore();
-  const toast = useToast();
 
   // State
   const state: TagStoreState = {
@@ -46,8 +45,8 @@ export const useTagStore = defineStore('tag', () => {
       // Merge and assign
       state.tagging.value = difference.concat(response);
     }
-    catch (error) {
-      toast.add({ severity: 'error', summary: 'Error fetching tags', detail: error, life: 3000 });
+    catch (e) {
+      error('Fetching tags', e);
     }
     finally {
       appStore.endIndeterminateLoading();

--- a/frontend/src/store/userStore.ts
+++ b/frontend/src/store/userStore.ts
@@ -3,7 +3,7 @@ import { computed, ref } from 'vue';
 
 import { userService } from '@/services';
 import { useAppStore } from '@/store';
-import { error } from '@/lib/primevue/useToast';
+import { error } from '@/services/toastService';
 
 import type { Ref } from 'vue';
 import type { IdentityProvider, User } from '@/types';
@@ -40,7 +40,7 @@ export const useUserStore = defineStore('user', () => {
       // Filter out any user without an IDP
       state.userSearch.value = response.filter((x: User) => !!x.identityId);
     }
-    catch (e) {
+    catch (e: any) {
       error('Searching users', e);
     }
     finally {

--- a/frontend/src/store/userStore.ts
+++ b/frontend/src/store/userStore.ts
@@ -1,9 +1,9 @@
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 
-import { useToast } from '@/lib/primevue';
 import { userService } from '@/services';
 import { useAppStore } from '@/store';
+import { error } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 import type { IdentityProvider, User } from '@/types';
@@ -40,8 +40,8 @@ export const useUserStore = defineStore('user', () => {
       // Filter out any user without an IDP
       state.userSearch.value = response.filter((x: User) => !!x.identityId);
     }
-    catch (error) {
-      useToast().add({ severity: 'error', summary: 'Error searching users', detail: error, life: 3000 });
+    catch (e) {
+      error('Searching users', e);
     }
     finally {
       appStore.endIndeterminateLoading();

--- a/frontend/src/views/list/ListObjectsView.vue
+++ b/frontend/src/views/list/ListObjectsView.vue
@@ -4,9 +4,9 @@ import { onBeforeMount, onErrorCaptured, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
 import { ObjectList } from '@/components/object';
-import { useToast } from '@/lib/primevue';
 import { useAuthStore, useBucketStore, usePermissionStore } from '@/store';
 import { RouteNames } from '@/utils/constants';
+import { error } from '@/lib/primevue/useToast';
 
 import type { Ref } from 'vue';
 import type { Bucket, BucketPermission } from '@/types';
@@ -35,8 +35,7 @@ async function getBucketName() {
 }
 
 onErrorCaptured((e: Error) => {
-  const toast = useToast();
-  toast.add({ severity: 'error', summary: 'Unable to load bucket information.', detail: e.message, life: 5000 });
+  error('Loading bucket', e);
 });
 
 onBeforeMount( async () => {

--- a/frontend/src/views/list/ListObjectsView.vue
+++ b/frontend/src/views/list/ListObjectsView.vue
@@ -6,7 +6,7 @@ import { useRouter } from 'vue-router';
 import { ObjectList } from '@/components/object';
 import { useAuthStore, useBucketStore, usePermissionStore } from '@/store';
 import { RouteNames } from '@/utils/constants';
-import { error } from '@/lib/primevue/useToast';
+import { error } from '@/services/toastService';
 
 import type { Ref } from 'vue';
 import type { Bucket, BucketPermission } from '@/types';
@@ -35,7 +35,7 @@ async function getBucketName() {
 }
 
 onErrorCaptured((e: Error) => {
-  error('Loading bucket', e);
+  error('Loading bucket', e.message);
 });
 
 onBeforeMount( async () => {


### PR DESCRIPTION
Not ready for review - some pieces are still missing.

(https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2960)

Given I need to be presented with a notification that my operation has succeeded or failed, I am presented with an appropriate and clear toast message.

Acceptance Criteria:

Review basic happy path operations provided in BCBox and ensure success or failure of that operation is presented with a meaningful toast notification.
Axios errors need to be a human-friendly error message
toast.add(...,life) - I noticed in some places we do have 3000ms and other places 5000ms. Choose one and standardize. Idea: set as a constant value like "DEFAULT_TOAST_TIMEOUT" or similar in our respective constants file. That or embed that into the toast call as a default argument so that we don't even need to specify it - only specify argument when we want to override default behaviour.

<img width="1261" alt="Screenshot 2023-05-05 at 10 43 08 AM" src="https://user-images.githubusercontent.com/117310853/236528810-3a583ccc-9805-459e-bacf-e18919c19873.png">

<img width="500" alt="Screenshot 2023-05-05 at 10 50 17 AM" src="https://user-images.githubusercontent.com/117310853/236530844-8c7f5c81-c29c-4927-883c-98698235a1c4.png">

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->