### PR TITLE
Update key handling during bucket config

### DIFF
--- a/frontend/src/components/bucket/BucketConfigForm.vue
+++ b/frontend/src/components/bucket/BucketConfigForm.vue
@@ -7,7 +7,7 @@ import Password from '@/components/form/Password.vue';
 import TextInput from '@/components/form/TextInput.vue';
 import { Button, useToast } from '@/lib/primevue';
 import { useAuthStore, useBucketStore } from '@/store';
-import { differential } from '@/utils/utils';
+import { differential, joinPath } from '@/utils/utils';
 
 import type { Bucket } from '@/types';
 
@@ -66,9 +66,13 @@ const onSubmit = async (values: any) => {
       bucket: values.bucket,
       bucketName: values.bucketName,
       endpoint: values.endpoint,
-      key: values.key ? values.key : '/',
       secretAccessKey: values.secretAccessKey,
     } as Bucket;
+
+    // Only add key for new configurations
+    if( !props.bucket && values.key ) {
+      formBucket.key = joinPath(values.key);
+    }
 
     props.bucket ?
       await bucketStore.updateBucket(props.bucket?.bucketId, differential(formBucket, initialValues)) :
@@ -130,7 +134,8 @@ const onCancel = () => {
         name="key"
         label="Key"
         placeholder="directory"
-        help-text="An optional path prefix within a bucket. The path will be created if it doesn't already exist."
+        help-text="A path prefix within a bucket. The path will be created if it doesn't already exist.
+          Will default to '/' if not provided. This value cannot be changed after the bucket is configured."
         :disabled="!!props.bucket"
       />
       <Button
@@ -152,7 +157,7 @@ const onCancel = () => {
 <style lang="scss" scoped>
 
 :deep(.p-inputtext) {
-  width: 65% !important;
+  width: 100% !important;
 }
 
 :deep(.pi-eye) {

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -4,6 +4,11 @@ export const BucketConfig = Object.freeze({
 });
 
 /**
+ * Default string delimiter
+ */
+export const DELIMITER = '/';
+
+/**
  * Max allowable tags to be added to an object
  * S3 max is 10, but one is reserved for the COMS `coms-id`
  */

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { DELIMITER } from '@/utils/constants';
+
 /**
  * @function differential
  * Create a key/value differential from source against comparer
@@ -18,6 +20,25 @@ export function differential(source: any, comparer: any): any {
  */
 export function isDebugMode(): boolean {
   return import.meta.env.MODE.toUpperCase() === 'DEBUG';
+}
+
+/**
+ * @function joinPath
+ * Joins a set of string arguments to yield a string path
+ * @param  {...string} items The strings to join on
+ * @returns {string} A path string with the specified delimiter
+ */
+export function joinPath(...items: Array<string>): string {
+  if (items && items.length) {
+    const parts: Array<string> = [];
+    items.forEach(p => {
+      if (p) p.split(DELIMITER).forEach(x => {
+        if (x && x.trim().length) parts.push(x);
+      });
+    });
+    return parts.join(DELIMITER);
+  }
+  else return '';
 }
 
 /**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

New key handling during bucket configuration. Per discussion BCBox has converged on

Key = undefined -> send w/o key; COMS defaults to /
Key = foo/bar -> send as foo/bar
Key = /foo/bar -> send as foo/bar

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->