### PR TITLE
ID attribute on help texts not resolving field name

### DIFF
--- a/frontend/src/components/form/Password.vue
+++ b/frontend/src/components/form/Password.vue
@@ -35,7 +35,7 @@ const { errorMessage, value } = useField<string>(toRef(props, 'name'));
       :feedback="false"
       toggle-mask
     />
-    <small id="`${name}-help`">{{ helptext }}</small>
+    <small :id="`${name}-help`">{{ helptext }}</small>
     <ErrorMessage
       :name="props.name"
     />

--- a/frontend/src/components/form/TextInput.vue
+++ b/frontend/src/components/form/TextInput.vue
@@ -35,7 +35,7 @@ const { errorMessage, value } = useField<string>(toRef(props, 'name'));
       :class="{ 'p-invalid': errorMessage }"
       :disabled="disabled"
     />
-    <small id="`${name}-help`">{{ helpText }}</small>
+    <small :id="`${name}-help`">{{ helpText }}</small>
     <ErrorMessage
       :name="name"
     />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
(fork for this one-liner, don't have contributor any more/again yet)

Randomly noticed this on help texts on fields
![image](https://github.com/bcgov/bcbox/assets/17445138/1c5dba67-cd04-4887-9b7c-bbb85a1f0e54)
`${name}-help`

Added the v-bind needed to the attribute. So it's not treating it as a string in HTML, but a JS template literal.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->