### PR TITLE
Bucket sidebar shows correct 'Managed By' users

### DIFF
--- a/frontend/src/components/bucket/BucketPermission.vue
+++ b/frontend/src/components/bucket/BucketPermission.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
-import { onMounted, ref } from 'vue';
+import { onBeforeMount, ref } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 import BucketPermissionAddUser from '@/components/bucket/BucketPermissionAddUser.vue';
@@ -64,7 +64,7 @@ const updateBucketPermission = (value: boolean, userId: string, permCode: string
   }
 };
 
-onMounted( async () => {
+onBeforeMount( async () => {
   await permissionStore.fetchBucketPermissions({ bucketId: props.bucketId });
   await permissionStore.mapBucketToUserPermissions(props.bucketId);
 });

--- a/frontend/src/components/bucket/BucketSidebar.vue
+++ b/frontend/src/components/bucket/BucketSidebar.vue
@@ -24,7 +24,6 @@ const permissionStore = usePermissionStore();
 const userStore = useUserStore();
 
 const { getBucketPermissions } = storeToRefs(permissionStore);
-const { userSearch } = storeToRefs(userStore);
 
 // State
 const managedBy: Ref<string | undefined> = ref();
@@ -53,7 +52,7 @@ async function load() {
 
   if (uniqueIds.length) {
     await userStore.fetchUsers({ userId: uniqueIds });
-    managedBy.value = userSearch.value.map((x) => x.fullName).join(', ');
+    managedBy.value = userStore.findUsersById(uniqueIds).map( x => x.fullName ).join(', ');
   }
 }
 

--- a/frontend/src/components/object/ObjectAccess.vue
+++ b/frontend/src/components/object/ObjectAccess.vue
@@ -34,7 +34,7 @@ async function load() {
 
   if( uniqueIds.length ) {
     await userStore.fetchUsers({ userId: uniqueIds });
-    managedBy.value = userStore.findUsersById(uniqueIds).map( x => x.fullName ).join( ', ');
+    managedBy.value = userStore.findUsersById(uniqueIds).map( x => x.fullName ).join(', ');
   }
 }
 

--- a/frontend/src/components/object/ObjectPermission.vue
+++ b/frontend/src/components/object/ObjectPermission.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
-import { onMounted, ref } from 'vue';
+import { onBeforeMount, ref } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 import ObjectPermissionAddUser from '@/components/object/ObjectPermissionAddUser.vue';
@@ -72,7 +72,7 @@ const updateObjectPermission = (value: boolean, userId: string, permCode: string
   }
 };
 
-onMounted(() => {
+onBeforeMount(() => {
   permissionStore.mapObjectToUserPermissions(props.objectId);
 });
 </script>

--- a/frontend/src/store/permissionStore.ts
+++ b/frontend/src/store/permissionStore.ts
@@ -143,6 +143,8 @@ export const usePermissionStore = defineStore('permission', () => {
 
   async function fetchBucketPermissions(params: BucketSearchPermissionsOptions = {}) {
     try {
+      appStore.beginIndeterminateLoading();
+
       const response = (await permissionService.bucketSearchPermissions(params)).data;
       const newPerms: Array<BucketPermission> = response.flatMap((x: any) => x.permissions);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

- Resolves an issue where bucket sidebar was showing every user in the store with manage instead of the requested bucket.
- Also shifted the permission tables to use OnBeforeMount to marginally speed up data loading

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->