### PR TITLE
Remove eager metadata fetch on object list

### DIFF
--- a/frontend/src/components/object/ObjectSidebar.vue
+++ b/frontend/src/components/object/ObjectSidebar.vue
@@ -7,7 +7,7 @@ import {
   ObjectTag
 } from '@/components/object';
 import { Button } from '@/lib/primevue';
-import { useAuthStore, useObjectStore, usePermissionStore, useTagStore } from '@/store';
+import { useAuthStore, useMetadataStore, useObjectStore, usePermissionStore, useTagStore } from '@/store';
 import { Permissions, RouteNames } from '@/utils/constants';
 
 // Props
@@ -21,6 +21,7 @@ const props = withDefaults(defineProps<Props>(), {});
 const emit = defineEmits(['close-object-info']);
 
 // Store
+const metadataStore = useMetadataStore();
 const objectStore = useObjectStore();
 const permissionStore = usePermissionStore();
 const tagStore = useTagStore();
@@ -37,6 +38,7 @@ watch( props, () => {
      (obj.public || permissionStore.isObjectActionAllowed(obj.id, getUserId.value, Permissions.READ, obj.bucketId)))
   {
     tagStore.fetchTagging({objectId: props.objectId});
+    metadataStore.fetchMetadata({objectId: props.objectId});
   }
 }, { immediate: true });
 </script>

--- a/frontend/src/components/object/ObjectTable.vue
+++ b/frontend/src/components/object/ObjectTable.vue
@@ -10,7 +10,7 @@ import {
 } from '@/components/object';
 import { ShareObjectButton } from '@/components/object/share';
 import { Button, Column, DataTable, Dialog, FilterMatchMode, InputText, InputSwitch, useToast } from '@/lib/primevue';
-import { useAuthStore, useAppStore, useMetadataStore, useObjectStore, usePermissionStore } from '@/store';
+import { useAuthStore, useAppStore, useObjectStore, usePermissionStore } from '@/store';
 import { Permissions } from '@/utils/constants';
 import { ButtonMode } from '@/utils/enums';
 import { formatDateLong } from '@/utils/formatters';
@@ -37,7 +37,6 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits(['show-object-info']);
 
 // Store
-const metadataStore = useMetadataStore();
 const objectStore = useObjectStore();
 const permissionStore = usePermissionStore();
 const { getObjects } = storeToRefs(objectStore);
@@ -81,17 +80,6 @@ watch( getObjects, async () => {
   // Filter object cache to this specific bucket
   const objs: Array<COMSObjectDataSource> = getObjects.value
     .filter( (x: COMSObject) => x.bucketId === props.bucketId ) as COMSObjectDataSource[];
-
-  // Update metadata store with metadata user has access to
-  const objIds: Array<string> = [];
-  objs.forEach( (x: COMSObject) => {
-    if( x.public || permissionStore.isObjectActionAllowed(
-      x.id, getUserId.value, Permissions.READ, props.bucketId as string))
-    {
-      objIds.push(x.id);
-    }
-  });
-  await metadataStore.fetchMetadata({objectId: objIds});
 
   tableData.value = objs.map( (x: COMSObjectDataSource) => {
     x.lastUpdatedDate = x.updatedAt ?? x.createdAt;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Do not load the metadata on the Object list page until it's needed (sidepane open).
Add metadata fetch on the object ID in the sidepane prop watch same as tagging.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->