### PR TITLE
Divide COMS object search request to limit URL length

### DIFF
--- a/frontend/src/services/objectService.ts
+++ b/frontend/src/services/objectService.ts
@@ -237,23 +237,24 @@ export default {
        *
        * TODO: consider creating a utils function
        * eg: `divideParam(params, attr)`
-       *     ... return Promise.all(divideParam(params, objectId).map(zparam => comsAxios().get(PATH, {params: zparam, headers: headers});
+       *      ...
+       *      return Promise.all(divideParam(params, objectId)
+       *        .map(zparam => comsAxios().get(PATH, {params: zparam, headers: headers});
        */
       let urlLimit = 2000;
-      // minus base url
-      const baseUrl = new URL(`${new ConfigService().getConfig().coms.apiPath}${PATH}`).toString().length;
-      urlLimit = urlLimit - baseUrl;
-      // minus deleteMarker=false
-      urlLimit = urlLimit - 19;
-      // minus latest=false
-      urlLimit = urlLimit - 13;
-      // minus a single bucketId (bucketId[]=<uuid>)
-      if (params.bucketId) { urlLimit = urlLimit - 48; }
+
+      const baseUrl = new URL(`${new ConfigService().getConfig().coms.apiPath}${PATH}`).toString();
+      urlLimit -= baseUrl.length; // subtract baseUrl length
+      if (params.deleteMarker) urlLimit -= 19; // subtract `deleteMarker=false`
+      if (params.latest) urlLimit -= 13; // subtract `latest=false`
+      if (params.bucketId) urlLimit -= 48; // subtract a single bucketId `bucketId[]=<uuid>`
       // if tagset parameters passed
       if (params.tagset) {
-        for (const [key, value] of Object.entries(params.tagset)) {
-          // @ts-ignore
-          urlLimit = urlLimit - 10 - key.length - value.length;
+        type TagsetObjectEntries = {
+          [K in keyof Tag]: [K, Tag[K]];
+        }[keyof Tag][];
+        for (const [key, value] of Object.entries(params.tagset) as TagsetObjectEntries) {
+          urlLimit -= (10 + key.length + value.length);
         }
       }
 

--- a/frontend/src/store/objectStore.ts
+++ b/frontend/src/store/objectStore.ts
@@ -110,8 +110,8 @@ export const useObjectStore = defineStore('object', () => {
   }
 
   async function fetchObjects(
-    params: ObjectSearchPermissionsOptions = {}, 
-    tagset?: Array<Tag>, 
+    params: ObjectSearchPermissionsOptions = {},
+    tagset?: Array<Tag>,
     metadata?: Array<MetadataPair>) {
     try {
       appStore.beginIndeterminateLoading();
@@ -137,7 +137,7 @@ export const useObjectStore = defineStore('object', () => {
             }
           }
 
-          response = (await objectService.searchObjects({
+          response = await objectService.searchObjects({
             bucketId: params.bucketId ? [params.bucketId] : undefined,
             objectId: uniqueIds,
             tagset: tagset ? tagset.reduce((acc, cur) => ({ ...acc, [cur.key]: cur.value }), {}) : undefined,
@@ -146,7 +146,7 @@ export const useObjectStore = defineStore('object', () => {
             // TODO: Verify if needed after versioning implemented
             deleteMarker: false,
             latest: true
-          }, headers)).data;
+          }, headers).then(r => r.data);
 
           // Remove old values matching search parameters
           const matches = (x: COMSObject) => (
@@ -159,7 +159,7 @@ export const useObjectStore = defineStore('object', () => {
           // Merge and assign
           state.objects.value = difference.concat(response);
 
-          // Track all the object IDs in this bucket that the user would have access to in the table 
+          // Track all the object IDs in this bucket that the user would have access to in the table
           // (even if filters are applied)
           if(!tagset?.length && !metadata?.length) {
             state.unfilteredObjectIds.value = state.objects.value

--- a/frontend/tests/unit/store/objectStore.spec.ts
+++ b/frontend/tests/unit/store/objectStore.spec.ts
@@ -181,7 +181,7 @@ describe('Object Store', () => {
         readPerm
       ];
 
-      searchObjectsSpy.mockReturnValue(Promise.resolve({ data: [obj] }) as any);
+      searchObjectsSpy.mockResolvedValue({ data: [obj] } as any);
       fetchObjectPermissionsSpy.mockReturnValue([readPerm] as any);
 
       await objectStore.fetchObjects({ bucketId: '000', userId: '123', bucketPerms: true });

--- a/frontend/tests/unit/store/objectStore.spec.ts
+++ b/frontend/tests/unit/store/objectStore.spec.ts
@@ -181,7 +181,7 @@ describe('Object Store', () => {
         readPerm
       ];
 
-      searchObjectsSpy.mockReturnValue({ data: [obj] } as any);
+      searchObjectsSpy.mockReturnValue(Promise.resolve({ data: [obj] }) as any);
       fetchObjectPermissionsSpy.mockReturnValue([readPerm] as any);
 
       await objectStore.fetchObjects({ bucketId: '000', userId: '123', bucketPerms: true });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3330

to load the objects table, if there are more than about 50 objects some browsers will show errors, because the COMS request url contains so many `objectId`'s and is too long.

In object search service function, i have split into multiple requests, each time, passing an acceptable number of the `objectId`'s

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->