### PR TITLE
SC-3335, bug: stop loading files into browser memory before upload

### DIFF
--- a/frontend/src/services/objectService.ts
+++ b/frontend/src/services/objectService.ts
@@ -55,8 +55,7 @@ export default {
       );
     }
 
-    const fd = await object.arrayBuffer();
-    return comsAxios(axiosOptions).put(PATH, fd, config);
+    return comsAxios(axiosOptions).put(PATH, object, config);
   },
 
   /**
@@ -354,7 +353,6 @@ export default {
       );
     }
 
-    const fd = await object.arrayBuffer();
-    return comsAxios(axiosOptions).put(`${PATH}/${objectId}`, fd, config);
+    return comsAxios(axiosOptions).put(`${PATH}/${objectId}`, object, config);
   },
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Prevent loading large files into browser memory before upload. In objectService.ts

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Requesting someone upload a large (>5 GB file) and ensure that file is not loaded into browser memory.