### PR TITLE
Fix object list refresh; get bucket details

### DIFF
--- a/frontend/src/components/object/ObjectProperties.vue
+++ b/frontend/src/components/object/ObjectProperties.vue
@@ -40,6 +40,7 @@ const version: Ref<Version | undefined> = ref(undefined);
 // Actions
 async function load() {
   object.value = objectStore.findObjectById(props.objectId);
+  await bucketStore.fetchBuckets({ bucketId: object.value?.bucketId });
   bucket.value = bucketStore.findBucketById(object.value?.bucketId as string);
 
   if( props.fullView ) {

--- a/frontend/src/components/object/ObjectTable.vue
+++ b/frontend/src/components/object/ObjectTable.vue
@@ -138,7 +138,7 @@ const filters = ref({
             outlined
             rounded
             aria-label="Filter"
-            @click="objectStore.fetchObjects({ bucketId: props.bucketId })"
+            @click="objectStore.fetchObjects({ bucketId: props.bucketId, userId: getUserId, bucketPerms: true })"
           />
         </div>
       </template>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

- evaluate bucket permissions when refreshing object list (ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3328?)
- previously, if you visited the file details page, the bucket name is missing from the 'properties' section. because people might navigate straight to this page (via a share link) we need to fetch the bucket details.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->