### PR TITLE
Filter out system user from COMS user search

### DIFF
--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -3,7 +3,7 @@ import { comsAxios } from './interceptors';
 import type { AxiosResponse } from 'axios';
 import type { SearchUsersOptions } from '@/types';
 
-import { COMS_SYSTEM_USER } from '@/utils/constants';
+import { SYSTEM_USER } from '@/utils/constants';
 
 const PATH = 'user';
 
@@ -15,9 +15,9 @@ export default {
    * @returns {Promise<AxiosResponse>} An axios response or empty array
    */
   searchForUsers(params: SearchUsersOptions): Promise<AxiosResponse> {
-    // delete userId prop if only contains 'system user'
-    const userIds = params.userId?.filter(id => id !== null && id !== COMS_SYSTEM_USER);
-    if(userIds?.length === 0) delete params.userId ;
+    // Drop userId param if it only contains the system user
+    const userIds = params.userId?.filter(id => id !== null && id !== SYSTEM_USER);
+    if (userIds?.length === 0) delete params.userId;
 
     if (Object.keys(params).length) {
       return comsAxios().get(`${PATH}`, { params: params });

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -3,6 +3,8 @@ import { comsAxios } from './interceptors';
 import type { AxiosResponse } from 'axios';
 import type { SearchUsersOptions } from '@/types';
 
+import { COMS_SYSTEM_USER } from '@/utils/constants';
+
 const PATH = 'user';
 
 export default {
@@ -10,10 +12,18 @@ export default {
    * @function searchForUsers
    * Returns a list of users based on the provided filtering parameters
    * @param {SearchUsersOptions} params SearchUsersOptions object containing the data to filter against
-   * @returns {Promise<AxiosResponse>} An axios response
+   * @returns {Promise<AxiosResponse>} An axios response or empty array
    */
   searchForUsers(params: SearchUsersOptions): Promise<AxiosResponse> {
-    return comsAxios().get(`${PATH}`, { params: params });
+    // delete userId prop if only contains 'system user'
+    const userIds = params.userId?.filter(id => id !== null && id !== COMS_SYSTEM_USER);
+    if(userIds?.length === 0) delete params.userId ;
+
+    if (Object.keys(params).length) {
+      return comsAxios().get(`${PATH}`, { params: params });
+    } else {
+      return Promise.resolve({ data: [] } as AxiosResponse);
+    }
   },
 
   /**

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -46,8 +46,10 @@ export const StorageKey = Object.freeze({
   CONFIG: 'config'
 });
 
-// user ID of system user record in COMS db
-export const COMS_SYSTEM_USER = '00000000-0000-0000-0000-000000000000';
+/**
+ * Default COMS System User ID
+ */
+export const SYSTEM_USER = '00000000-0000-0000-0000-000000000000';
 
 export const ToastTimeout = Object.freeze({
   ERROR: 5000,

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -46,6 +46,9 @@ export const StorageKey = Object.freeze({
   CONFIG: 'config'
 });
 
+// user ID of system user record in COMS db
+export const COMS_SYSTEM_USER = '00000000-0000-0000-0000-000000000000';
+
 export const ToastTimeout = Object.freeze({
   ERROR: 5000,
   INFO: 3000,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

With recent change to COMS where new objects are 'created by' 'system user' (https://github.com/bcgov/common-object-management-service/pull/211)
We found errors in bcbox when searching for details of that user when 
- showing who owns the file on the file details page
- listing who has object permissions
these errors were caused by searching for the 'system user' in COMS.
A quick fix is to filter out the system user from searches.
future work should address the ux where 'created by' and 'updated by' may now appear blank for new records after a sync.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->