### PR TITLE
SC-3338, fix: prevent single slash in BucketConfigForm error

### DIFF
--- a/frontend/src/components/bucket/BucketConfigForm.vue
+++ b/frontend/src/components/bucket/BucketConfigForm.vue
@@ -70,7 +70,7 @@ const onSubmit = async (values: any) => {
     } as Bucket;
 
     // Only add key for new configurations
-    if( !props.bucket && values.key ) {
+    if( !props.bucket && values.key && joinPath(values.key)) {
       formBucket.key = joinPath(values.key);
     }
 

--- a/frontend/src/components/bucket/BucketConfigForm.vue
+++ b/frontend/src/components/bucket/BucketConfigForm.vue
@@ -52,7 +52,7 @@ const schema = object({
   bucket: string().max(255).required().label('Bucket'),
   bucketName: string().max(255).required().label('Bucket name'),
   endpoint: string().max(255).required().label('Endpoint'),
-  key: string().max(255).label('Key'),
+  key: string().matches(/^[^\\]+$/, 'Sub-path must not contain backslashes').max(255).label('Key'),
   secretAccessKey: string().max(255).required().label('Secret Access Key')
 });
 

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -36,7 +36,7 @@ export function joinPath(...items: Array<string>): string {
         if (x && x.trim().length) parts.push(x);
       });
     });
-    return parts.join(DELIMITER);
+    return parts.join(DELIMITER) ?? '';
   }
   else return '';
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Fixing joinPath util so it doesn't return undefined when a single slash is input.
Fixing BucketConfigForm.vue so empty strings returned by joinPath don't add issues with bucket creation.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3338