### PR TITLE
Update bucket name in sync modal after page load

### DIFF
--- a/frontend/src/components/common/SyncButton.vue
+++ b/frontend/src/components/common/SyncButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref } from 'vue';
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { Button, Dialog, useToast } from '@/lib/primevue';
@@ -42,13 +42,14 @@ const onSubmit = () => {
   displaySyncDialog.value = false;
 };
 
-onMounted( () => {
+const onClick = () => {
+  displaySyncDialog.value = true;
   if (props.bucketId) {
     name.value = bucketStore.findBucketById(props.bucketId)?.bucketName ?? '';
   } else if (props.objectId) {
     name.value = objectStore.findObjectById(props.objectId)?.name ?? '';
   }
-});
+};
 </script>
 
 <template>
@@ -109,7 +110,7 @@ onMounted( () => {
 
   <Button
     class="p-button-lg p-button-text"
-    @click="displaySyncDialog = true"
+    @click="onClick"
   >
     <font-awesome-icon icon="fa-solid fa-sync" />
   </Button>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
This PR fixes a bug where the bucket name in the sync modal isn't updated, if the bucket name was updated after page load.

<!-- Describe your changes in detail -->
Previously, the bucket name was fetched when `onMounted` - it's now been moved to when the sync button is clicked instead.

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3353

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
N/A