### PR TITLE
Fix bug caused by assigned undefined array to new set

### DIFF
--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -18,7 +18,15 @@ export default {
     // Filter out SYSTEM_USER from userId param
     const userIds = params.userId?.filter(id => id !== null && id !== SYSTEM_USER);
     // Drop userId param if it only contains the system user or assign back to params object, without duplicates
-    userIds?.length === 0 ? delete params.userId : params.userId = [...new Set(userIds)];
+    if (userIds) {
+      if (userIds.length === 0) {
+        delete params.userId;
+      }
+      else {
+        params.userId = [...new Set(userIds)];
+      }
+    }
+
 
     if (Object.keys(params).length) {
       return comsAxios().get(`${PATH}`, { params: params });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Resolves a bug caused by assigned an undefined array to a new set. This caused an empty array parameter to be sent to COMS during user searches, somehow resulting in duplicate users in the user store.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->