### PR TITLE
Add clarification to version update action for non-versioned buckets

### DIFF
--- a/frontend/src/components/object/ObjectUploadBasic.vue
+++ b/frontend/src/components/object/ObjectUploadBasic.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue';
 
 import { ObjectMetadataTagForm } from '@/components/object';
 import { Button, Dialog, useConfirm, useToast } from '@/lib/primevue';
-import { useAppStore, useMetadataStore, useObjectStore, useTagStore } from '@/store';
+import { useAppStore, useMetadataStore, useObjectStore, useTagStore, useVersionStore } from '@/store';
 
 import type { Ref } from 'vue';
 import type { ObjectMetadataTagFormType } from '@/components/object/ObjectMetadataTagForm.vue';
@@ -24,6 +24,7 @@ const appStore = useAppStore();
 const metadataStore = useMetadataStore();
 const objectStore = useObjectStore();
 const tagStore = useTagStore();
+const versionStore = useVersionStore();
 
 // State
 const fileInput: Ref<any> = ref(null);
@@ -41,8 +42,13 @@ const confirm = useConfirm();
 const toast = useToast();
 
 const confirmUpdate = () => {
+  let confirmMessage =  'Please confirm that you want to upload a new version.';
+  if (versionStore.findS3VersionByObjectId(props.objectId) === null) {
+    confirmMessage = 'This is a non-versioned bucket. ' +
+      'Uploading a new version will overwrite the current version.';
+  }
   confirm.require({
-    message: 'Please confirm that you want to upload a new version.',
+    message: confirmMessage,
     header: 'Upload new version',
     acceptLabel: 'Confirm',
     rejectLabel: 'Cancel',

--- a/frontend/src/store/versionStore.ts
+++ b/frontend/src/store/versionStore.ts
@@ -126,7 +126,9 @@ export const useVersionStore = defineStore('version', () => {
   function findVersionsByObjectId(objectId: string) {
     return state.versions.value.filter((x: Version) => x.objectId === objectId);
   }
-
+  function findS3VersionByObjectId(objectId: string) {
+    return state.versions.value.filter((x: Version) => x.objectId === objectId)[0]?.s3VersionId;
+  }
   return {
     // State
     ...state,
@@ -143,7 +145,8 @@ export const useVersionStore = defineStore('version', () => {
     findMetadataValue,
     findTaggingByVersionId,
     findVersionById,
-    findVersionsByObjectId
+    findVersionsByObjectId,
+    findS3VersionByObjectId,
   };
 });
 


### PR DESCRIPTION
This change will display a confirmation pop up when a user tries to upload a non-version bucket file, notifying that action will replace the file and previous version will no longer be available.


<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->