### PR TITLE
Create toast if user updates credentials for bucket that has children

### DIFF
--- a/frontend/src/components/bucket/BucketConfigForm.vue
+++ b/frontend/src/components/bucket/BucketConfigForm.vue
@@ -100,11 +100,7 @@ const onSubmit = async (values: any) => {
     toast.success('Configuring bucket', 'Bucket configuration successful');
 
     if ((bucketChanges.accessKeyId || bucketChanges.secretAccessKey) && hasChildren) {
-      toast.info(
-        'Any child buckets?',
-        "Don't forget to update their credentials too, if you're managing them in BCBox",
-        { life: 10000 }
-      );
+      toast.info('Buckets under this bucket', 'Remember to update their credentials where applicable', { life: 10000 });
     }
   } catch (error: any) {
     toast.error('Configuring bucket', error);

--- a/frontend/src/components/bucket/BucketConfigForm.vue
+++ b/frontend/src/components/bucket/BucketConfigForm.vue
@@ -7,7 +7,7 @@ import Password from '@/components/form/Password.vue';
 import TextInput from '@/components/form/TextInput.vue';
 import { Button, useToast } from '@/lib/primevue';
 import { useAuthStore, useBucketStore } from '@/store';
-import { differential, joinPath } from '@/utils/utils';
+import { differential, getBucketPath, joinPath } from '@/utils/utils';
 
 import type { Bucket } from '@/types';
 
@@ -77,14 +77,35 @@ const onSubmit = async (values: any) => {
       formBucket.key = joinPath(values.key);
     }
 
+    const bucketChanges = differential(formBucket, initialValues);
+
     props.bucket
-      ? await bucketStore.updateBucket(props.bucket?.bucketId, differential(formBucket, initialValues))
+      ? await bucketStore.updateBucket(props.bucket?.bucketId, bucketChanges)
       : await bucketStore.createBucket(formBucket);
 
     await bucketStore.fetchBuckets({ userId: getUserId.value, objectPerms: true });
+
+    // trim trailing "//", if present
+    // (modifying getBucketPath() instead seems to break nested bucket display [PR-146])
+    const currBucketPath = getBucketPath(initialValues as Bucket).endsWith('//')
+      ? getBucketPath(initialValues as Bucket).slice(0, -1)
+      : getBucketPath(initialValues as Bucket);
+
+    const hasChildren = bucketStore.buckets.some(
+      (b) => getBucketPath(b).includes(currBucketPath) && getBucketPath(b) !== currBucketPath
+    );
+
     emit('submit-bucket-config');
 
     toast.success('Configuring bucket', 'Bucket configuration successful');
+
+    if ((bucketChanges.accessKeyId || bucketChanges.secretAccessKey) && hasChildren) {
+      toast.info(
+        'Any child buckets?',
+        "Don't forget to update their credentials too, if you're managing them in BCBox",
+        { life: 10000 }
+      );
+    }
   } catch (error: any) {
     toast.error('Configuring bucket', error);
   }

--- a/frontend/src/components/bucket/BucketTable.vue
+++ b/frontend/src/components/bucket/BucketTable.vue
@@ -8,7 +8,7 @@ import { SyncButton } from '@/components/common';
 import { Button, Column, Dialog, TreeTable, useConfirm } from '@/lib/primevue';
 import { useAppStore, useAuthStore, useBucketStore, usePermissionStore } from '@/store';
 import { DELIMITER, Permissions } from '@/utils/constants';
-import { joinPath } from '@/utils/utils';
+import { getBucketPath, joinPath } from '@/utils/utils';
 
 import type { TreeTableExpandedKeys } from 'primevue/treetable';
 import type { Ref } from 'vue';
@@ -65,11 +65,6 @@ const confirmDeleteBucket = (bucketId: string) => {
 async function deleteBucket(bucketId: string) {
   await bucketStore.deleteBucket(bucketId);
   await bucketStore.fetchBuckets({ userId: getUserId.value, objectPerms: true });
-}
-
-/** Returns a full canonical path to a Bucket or fake tree data */
-function getBucketPath(bucket: Bucket): string {
-  return `${bucket.endpoint}/${bucket.bucket}/${bucket.key}`;
 }
 
 /** Get the full path to the first part of its key */

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -1,6 +1,7 @@
 import { DELIMITER } from '@/utils/constants';
 import ConfigService from '@/services/configService';
 import { ExcludeTypes } from '@/utils/enums';
+import type { Bucket } from '@/types';
 
 /**
  * @function differential
@@ -115,4 +116,14 @@ export function setDispositionHeader(filename: string) {
   } else {
     return dispositionHeader.concat(`; filename*=UTF-8''${encodedFilename}`);
   }
+}
+
+/**
+ * @function getBucketPath
+ * Returns a full canonical path to a Bucket
+ * @param {Bucket} bucket COMS bucket
+ * @returns {string} full canonical path to bucket
+ */
+export function getBucketPath(bucket: Bucket): string {
+  return `${bucket.endpoint}/${bucket.bucket}/${bucket.key}`;
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
This PR adds an additional toast, whenever credentials are updated for a bucket that has children:

<img width="440" alt="Screenshot 2023-12-08 at 12 39 29 PM" src="https://github.com/bcgov/bcbox/assets/103449568/7af892c3-8410-4d19-97bf-bc84f9f5315e">

The additional toast is displayed for 10 seconds.

Although the toast asks the user if there's any child buckets, it's only displayed if there *are* child buckets managed inside COMS/BCBox.

<!-- Describe your changes in detail -->

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3372

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
The single quotes in the toast message are conflicting with the linter:
* If escaping the single quotes within a single quote delineated string (i.e `'Don\'t forget...'`), the linter will convert it back into double quotes and remove the escape sequence (i.e. `"Don't forget..."`
* If using double quotes without escaping `\'`, it results in a linter error