### PR TITLE
Poll userId before fetching buckets list

### DIFF
--- a/frontend/src/components/bucket/BucketList.vue
+++ b/frontend/src/components/bucket/BucketList.vue
@@ -41,6 +41,11 @@ const closeBucketConfig = () => {
 };
 
 onMounted(async () => {
+  while (!getUserId.value) {
+    await new Promise((r) => {
+      setTimeout(r, 500);
+    });
+  }
   await bucketStore.fetchBuckets({ userId: getUserId.value, objectPerms: true });
 });
 </script>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Quick fix for race condition between getUserId and GET /bucket, by getting the latter to poll on the user ID first.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->