### PR TITLE
Skip pop-up blocker

### DIFF
--- a/frontend/src/components/object/DownloadObjectButton.vue
+++ b/frontend/src/components/object/DownloadObjectButton.vue
@@ -28,8 +28,9 @@ const displayNoFileDlg = ref(false);
 const download = () => {
   if (props.ids.length) {
     // For now we are looping the supplied IDs (if multiple selected) until there is a batching feature
-    props.ids.forEach((i) => {
-      objectStore.downloadObject(i, props.versionId);
+    props.ids.forEach(async (i) => {
+      var url = await objectStore.downloadObject(i, props.versionId);
+      window.open(url, '_blank');
     });
   } else {
     displayNoFileDlg.value = true;

--- a/frontend/src/components/object/DownloadObjectButton.vue
+++ b/frontend/src/components/object/DownloadObjectButton.vue
@@ -2,9 +2,11 @@
 import { ref } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
-import { Button, Dialog } from '@/lib/primevue';
+import { Button, Dialog, useToast } from '@/lib/primevue';
 import { useObjectStore } from '@/store';
 import { ButtonMode } from '@/utils/enums';
+
+const toast = useToast();
 
 // Props
 type Props = {
@@ -28,10 +30,19 @@ const displayNoFileDlg = ref(false);
 const download = () => {
   if (props.ids.length) {
     // For now we are looping the supplied IDs (if multiple selected) until there is a batching feature
-    props.ids.forEach(async (i) => {
-      var url = await objectStore.downloadObject(i, props.versionId);
-      window.open(url, '_blank');
-    });
+    let alerted = false;
+    for (let i of props.ids) {
+      // get S3 url
+      objectStore.getObjectUrl(i, props.versionId).then((url) => {
+        // open new tab, window or save dialog
+        const newTab = window.open(url, '_blank');
+        // if browser blocked new tab
+        if (newTab === null && !alerted) {
+          toast.warn('Downloading Objects', 'Your browser blocked multiple new tabs from opening.', { life: 0 });
+          alerted = true;
+        }
+      });
+    }
   } else {
     displayNoFileDlg.value = true;
   }

--- a/frontend/src/services/objectService.ts
+++ b/frontend/src/services/objectService.ts
@@ -138,8 +138,7 @@ export default {
         }
       })
       .then((response) => {
-        const url = response.data;
-        window.open(url, '_blank');
+        return response.data;
       });
   },
 

--- a/frontend/src/services/objectService.ts
+++ b/frontend/src/services/objectService.ts
@@ -127,19 +127,15 @@ export default {
    * Get an object
    * @param {string} objectId The id for the object to get
    * @param {string} versionId An optional versionId
+   * @returns {Promise} An axios response
    */
   getObject(objectId: string, versionId?: string) {
-    // Running in 'url' download mode only, could add options for other modes if needed
-    return comsAxios()
-      .get(`${PATH}/${objectId}`, {
-        params: {
-          versionId: versionId,
-          download: 'url'
-        }
-      })
-      .then((response) => {
-        return response.data;
-      });
+    return comsAxios().get(`${PATH}/${objectId}`, {
+      params: {
+        versionId: versionId,
+        download: 'url'
+      }
+    });
   },
 
   /**

--- a/frontend/src/store/objectStore.ts
+++ b/frontend/src/store/objectStore.ts
@@ -91,10 +91,10 @@ export const useObjectStore = defineStore('object', () => {
     }
   }
 
-  async function downloadObject(objectId: string, versionId?: string) {
+  async function getObjectUrl(objectId: string, versionId?: string) {
     try {
       appStore.beginIndeterminateLoading();
-      return await objectService.getObject(objectId, versionId);
+      return objectService.getObject(objectId, versionId).then((response) => response.data);
     } catch (error: any) {
       toast.error('Downloading object', error);
     } finally {
@@ -270,7 +270,7 @@ export const useObjectStore = defineStore('object', () => {
     // Actions
     createObject,
     deleteObject,
-    downloadObject,
+    getObjectUrl,
     fetchObjects,
     findObjectById,
     headObject,

--- a/frontend/src/store/objectStore.ts
+++ b/frontend/src/store/objectStore.ts
@@ -94,7 +94,7 @@ export const useObjectStore = defineStore('object', () => {
   async function downloadObject(objectId: string, versionId?: string) {
     try {
       appStore.beginIndeterminateLoading();
-      await objectService.getObject(objectId, versionId);
+      return await objectService.getObject(objectId, versionId);
     } catch (error: any) {
       toast.error('Downloading object', error);
     } finally {

--- a/frontend/tests/unit/store/objectStore.spec.ts
+++ b/frontend/tests/unit/store/objectStore.spec.ts
@@ -133,11 +133,11 @@ describe('Object Store', () => {
     });
   });
 
-  describe('downloadObject', () => {
+  describe('getObjectUrl', () => {
     it('gets the most recent object', async () => {
       getObjectSpy.mockReturnValue({} as any);
 
-      await objectStore.downloadObject(obj.id);
+      await objectStore.getObjectUrl(obj.id);
 
       expect(beginIndeterminateLoadingSpy).toHaveBeenCalledTimes(1);
       expect(getObjectSpy).toHaveBeenCalledTimes(1);
@@ -148,7 +148,7 @@ describe('Object Store', () => {
     it('gets the object by version', async () => {
       getObjectSpy.mockReturnValue({} as any);
 
-      await objectStore.downloadObject(obj.id, '1');
+      await objectStore.getObjectUrl(obj.id, '1');
 
       expect(beginIndeterminateLoadingSpy).toHaveBeenCalledTimes(1);
       expect(getObjectSpy).toHaveBeenCalledTimes(1);
@@ -161,7 +161,7 @@ describe('Object Store', () => {
         throw new Error();
       });
 
-      await objectStore.downloadObject(obj.id);
+      await objectStore.getObjectUrl(obj.id);
 
       expect(beginIndeterminateLoadingSpy).toHaveBeenCalledTimes(1);
       expect(getObjectSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
ticket: https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3508

# Description

Caused by the browser settings relating to pop-ups and new tabs.

- Edge: Pop-ups and redirects > on | off
- chrome: Pop-ups and redirects >
  - Sites can send pop-ups and use redirects
  - Don't allow sites to send pop-ups or use redirects
- Firefox: Block pop-up windows > on | off

mdn docs:
Modern browsers have strict popup blocker policies. Popup windows must be opened in direct response to user input, and a separate user gesture event is required for each Window.open() call. 

So my proposed change is to show a toast message (in case user has permanantly blocked popups and arent aware of the cause). To allow for this, the window.open() is now invoked in the component.

## commits:
- Move window.open event to the vue component

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->