### PR TITLE
Rewrite getConfig to attempt to reacquire config if missing

### DIFF
--- a/frontend/src/services/configService.ts
+++ b/frontend/src/services/configService.ts
@@ -54,11 +54,25 @@ export default class ConfigService {
    */
   public getConfig(): any | undefined {
     try {
-      const cfgString = storageType.getItem(StorageKey.CONFIG);
-      return cfgString ? JSON.parse(cfgString) : undefined;
+      let cfgString = storageType.getItem(StorageKey.CONFIG);
+      if (cfgString === null) {
+        // eslint-disable-next-line no-console
+        console.warn('Configuration missing. Attempting to reacquire...');
+        axios
+          .get('/config')
+          .then(({ data }) => {
+            storageType.setItem(StorageKey.CONFIG, JSON.stringify(data));
+            cfgString = data;
+          })
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.error(`Failed to reacquire configuration: ${err}`);
+          });
+      }
+      return JSON.parse(cfgString as string);
     } catch (err: unknown) {
       // eslint-disable-next-line no-console
-      console.error(`Missing configuration: ${err}`);
+      console.error(`Unparseable configuration: ${err}`);
       return undefined;
     }
   }

--- a/frontend/src/services/configService.ts
+++ b/frontend/src/services/configService.ts
@@ -32,7 +32,12 @@ export default class ConfigService {
     return new Promise((resolve, reject) => {
       if (storageType.getItem(StorageKey.CONFIG) === null) {
         axios
-          .get('/config')
+          .get('/config', {
+            headers: {
+              'Cache-Control': 'no-cache',
+              'Pragma': 'no-cache'
+            }
+          })
           .then(({ data }) => {
             storageType.setItem(StorageKey.CONFIG, JSON.stringify(data));
             resolve(new ConfigService());
@@ -59,7 +64,12 @@ export default class ConfigService {
         // eslint-disable-next-line no-console
         console.warn('Configuration missing. Attempting to reacquire...');
         axios
-          .get('/config')
+          .get('/config', {
+            headers: {
+              'Cache-Control': 'no-cache',
+              'Pragma': 'no-cache'
+            }
+          })
           .then(({ data }) => {
             storageType.setItem(StorageKey.CONFIG, JSON.stringify(data));
             cfgString = data;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
While this does not solve latent navigation issues when they show up because getConfig must remain a synchronous function, this does allow the application to attempt to recover should the user try further navigation actions after it finds the configuration is somehow missing from session storage.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3533](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3533)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->