### PR TITLE
Restrict bucket fetch only if Ids are provided

### DIFF
--- a/frontend/src/store/bucketStore.ts
+++ b/frontend/src/store/bucketStore.ts
@@ -82,7 +82,9 @@ export const useBucketStore = defineStore('bucket', () => {
         ];
 
         let response = Array<Bucket>();
-        response = (await bucketService.searchBuckets({ bucketId: uniqueIds })).data;
+        if (uniqueIds.length) {
+          response = (await bucketService.searchBuckets({ bucketId: uniqueIds })).data;
+        }
 
         // Remove old values matching search parameters
         const matches = (x: Bucket) => !params?.bucketId || x.bucketId === params.bucketId;


### PR DESCRIPTION
When login using BCedID all buckets are seems to be showing up, this will restrict fetch only if buckets Ids are provided.
[
SC3610](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3610)

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->