### PR TITLE
Invite link modal: clarify that links are single-use

### DIFF
--- a/frontend/src/components/common/InviteButton.vue
+++ b/frontend/src/components/common/InviteButton.vue
@@ -119,7 +119,10 @@ onMounted(() => {
 
     <ul class="mb-4">
       <li>If a user already has permissions, you can link them with a share link</li>
-      <li>Invite someone using an invite link</li>
+      <li>
+        Invite someone using an invite link - the links are single-use; you must generate a new link for each user you
+        intend to send this to
+      </li>
       <li>To share publicly or with a direct link, you must set the file to public - this only works for objects</li>
     </ul>
     <TabView>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Change the text in the invite link modal, to make it clear that links are single-use.

Original wording:

> Invite someone using an invite link

New wording:

> Invite someone using an invite link - the links are single-use; you must generate a new link for each user you intend to send this to

![Screenshot 2024-04-03 at 5 30 14 PM](https://github.com/bcgov/bcbox/assets/103449568/52259089-61c1-4ac1-a333-e6cb4fe429dd)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3611

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
N/A