### PR TITLE
Fix object share button aria-label

### DIFF
--- a/frontend/src/components/common/InviteButton.vue
+++ b/frontend/src/components/common/InviteButton.vue
@@ -283,7 +283,7 @@ onMounted(() => {
   <Button
     v-tooltip.bottom="`${props.labelText} Share`"
     class="p-button-lg p-button-text primary"
-    aria-label="`${props.labelText} Share`"
+    :aria-label="`${props.labelText} Share`"
     @click="displayInviteDialog = true"
   >
     <font-awesome-icon icon="fa-solid fa-share-alt" />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This fixes the `aria-label` for the "object share" button for objects, so that screen readers can correctly read the button.

There were no issues with the visible tooltip.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3653

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Much of the heavy lifting for this ticket seems to have been already done in [SHOWCASE-3656](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3656) and [SHOWCASE-3657](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3657) (and possibly [SHOWCASE-3515](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3515), when Primevue got updated to 3.52)
* See #189 and #188