### PR TITLE
Object permissions: auto-add READ permissions when adding user

### DIFF
--- a/frontend/src/components/object/ObjectPermission.vue
+++ b/frontend/src/components/object/ObjectPermission.vue
@@ -86,7 +86,10 @@ onBeforeMount(() => {
       </Button>
     </div>
     <div v-else>
-      <ObjectPermissionAddUser @cancel-search-users="cancelSearchUsers" />
+      <ObjectPermissionAddUser
+        :object-id="object?.id!"
+        @cancel-search-users="cancelSearchUsers"
+      />
     </div>
 
     <DataTable
@@ -106,9 +109,7 @@ onBeforeMount(() => {
         <div class="flex justify-content-center">
           <div>
             <h3>There are no users associated specifically with this file.</h3>
-            <span>
-              Permissions at the folder level still apply but aren't shown here.
-            </span>
+            <span>Permissions at the folder level still apply but aren't shown here.</span>
           </div>
         </div>
       </template>
@@ -130,7 +131,8 @@ onBeforeMount(() => {
             v-model="data.read"
             input-id="read"
             :binary="true"
-            @update:model-value="(value:boolean) => updateObjectPermission(value, data.userId, Permissions.READ)"
+            :disabled="data.read"
+            @update:model-value="(value: boolean) => updateObjectPermission(value, data.userId, Permissions.READ)"
           />
         </template>
       </Column>
@@ -144,7 +146,7 @@ onBeforeMount(() => {
             v-model="data.update"
             input-id="update"
             :binary="true"
-            @update:model-value="(value:boolean) => updateObjectPermission(value, data.userId, Permissions.UPDATE)"
+            @update:model-value="(value: boolean) => updateObjectPermission(value, data.userId, Permissions.UPDATE)"
           />
         </template>
       </Column>
@@ -158,7 +160,7 @@ onBeforeMount(() => {
             v-model="data.delete"
             input-id="delete"
             :binary="true"
-            @update:model-value="(value:boolean) => updateObjectPermission(value, data.userId, Permissions.DELETE)"
+            @update:model-value="(value: boolean) => updateObjectPermission(value, data.userId, Permissions.DELETE)"
           />
         </template>
       </Column>
@@ -172,7 +174,7 @@ onBeforeMount(() => {
             v-model="data.manage"
             input-id="manage"
             :binary="true"
-            @update:model-value="(value:boolean) => updateObjectPermission(value, data.userId, Permissions.MANAGE)"
+            @update:model-value="(value: boolean) => updateObjectPermission(value, data.userId, Permissions.MANAGE)"
           />
         </template>
       </Column>

--- a/frontend/src/components/object/ObjectPermissionAddUser.vue
+++ b/frontend/src/components/object/ObjectPermissionAddUser.vue
@@ -1,30 +1,23 @@
 <script setup lang="ts">
-import { storeToRefs } from 'pinia';
-
 import SearchUsers from '@/components/form/SearchUsers.vue';
-import { useConfigStore, usePermissionStore } from '@/store';
+import { usePermissionStore } from '@/store';
+import { Permissions } from '@/utils/constants';
 
 import type { User } from '@/types';
 
+// Props
+type Props = {
+  objectId: string;
+};
+
+const props = withDefaults(defineProps<Props>(), {});
+
 // Store
-const { getConfig } = storeToRefs(useConfigStore());
 const permissionStore = usePermissionStore();
 
 // Actions
-const onAdd = (selectedUser: User) => {
-  const idp = getConfig.value.idpList.find((idp: any) => idp.idp === selectedUser?.idp);
-
-  permissionStore.addObjectUser({
-    userId: selectedUser.userId,
-    idpName: idp?.name,
-    elevatedRights: idp?.elevatedRights,
-    fullName: selectedUser.fullName,
-    create: false,
-    read: false,
-    update: false,
-    delete: false,
-    manage: false
-  });
+const onAdd = async (selectedUser: User) => {
+  if (props.objectId) await permissionStore.addObjectPermission(props.objectId, selectedUser.userId, Permissions.READ);
 };
 </script>
 

--- a/frontend/src/store/permissionStore.ts
+++ b/frontend/src/store/permissionStore.ts
@@ -85,11 +85,6 @@ export const usePermissionStore = defineStore('permission', () => {
     try {
       appStore.beginIndeterminateLoading();
       await permissionService.objectAddPermissions(objectId, [{ userId, permCode }]);
-
-      const forceToggleReadOn: Array<string> = [Permissions.UPDATE, Permissions.DELETE, Permissions.MANAGE];
-      if (forceToggleReadOn.some((x: string) => x === permCode)) {
-        await permissionService.objectAddPermissions(objectId, [{ userId, permCode: Permissions.READ }]);
-      }
     } catch (error: any) {
       toast.error('Adding object permission', error);
     } finally {
@@ -114,7 +109,7 @@ export const usePermissionStore = defineStore('permission', () => {
     }
   }
 
-  async function deleteBucketPermission(bucketId: string, userId: string, permCode: string): Promise<void>{
+  async function deleteBucketPermission(bucketId: string, userId: string, permCode: string): Promise<void> {
     try {
       appStore.beginIndeterminateLoading();
       await permissionService.bucketDeletePermission(bucketId, { userId, permCode });
@@ -130,11 +125,6 @@ export const usePermissionStore = defineStore('permission', () => {
     try {
       appStore.beginIndeterminateLoading();
       await permissionService.objectDeletePermission(objectId, { userId, permCode });
-
-      if (permCode === Permissions.READ) {
-        const forceToggleOnRead: Array<string> = [Permissions.UPDATE, Permissions.DELETE, Permissions.MANAGE];
-        await permissionService.objectDeletePermission(objectId, { userId, permCode: forceToggleOnRead });
-      }
     } catch (error: any) {
       toast.error('Deleting object permission', error);
     } finally {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
When adding a user to the object permissions, READ permissions are now also added.

The READ permission checkbox has also been disabled, as this is the "minimum" permission level. If the user wants to remove READ permissions for a user, they can do so by removing the user entirely using the red "remove" button for the user.

<!-- Why is this change required? What problem does it solve? -->
This allows us to reduce COMS API calls and therefore lag in the UI (see "further comments" at bottom).

<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3664

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Previously, toggling any of the permissions forces a check on the READ permission and vice versa, since READ is a prerequisite for all of the others. This resulted in additional COMS API calls, resulting in glitchy/delayed checkbox behaviour as it waits for those API calls to return.

However, because the READ checkbox is now disabled (and is always checked), we can safely allow the user to toggle the other permissions without having to make those API calls to enforce READ permissions, so that code in `store/permissionStore.ts` has been removed (along with the laggy checkboxes that result).