### PR TITLE
Display confirmation dialog and toasts on toggling file to public

### DIFF
--- a/frontend/src/components/object/ObjectPermission.vue
+++ b/frontend/src/components/object/ObjectPermission.vue
@@ -66,6 +66,7 @@ onBeforeMount(() => {
         class="ml-4"
         :bucket-id="object.bucketId"
         :object-id="object.id"
+        :object-name="object.name"
         :object-public="object.public"
         :user-id="getUserId"
       />

--- a/frontend/src/components/object/ObjectTable.vue
+++ b/frontend/src/components/object/ObjectTable.vue
@@ -262,9 +262,7 @@ const selectedFilters = (payload: any) => {
       >
         <template #body="{ data }">
           <div>
-            <router-link
-              :to="{ name: RouteNames.DETAIL_OBJECTS, query: { objectId: data.id } }"
-            >
+            <router-link :to="{ name: RouteNames.DETAIL_OBJECTS, query: { objectId: data.id } }">
               <span v-tooltip.bottom="'View file details'">
                 {{ data.name }}
               </span>
@@ -307,6 +305,7 @@ const selectedFilters = (payload: any) => {
             v-if="props.bucketId && getUserId"
             :bucket-id="props.bucketId"
             :object-id="data.id"
+            :object-name="data.name"
             :object-public="data.public"
             :user-id="getUserId"
           />


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
<!-- Describe your changes in detail -->
Setting the "set to public" switch to "on" (in both the object table and file permissions modal) now opens an additional modal that asks the user to confirm before doing so:

![Screenshot 2024-05-15 at 4 10 24 PM](https://github.com/bcgov/bcbox/assets/103449568/b2dcef97-994a-4d1c-8108-291014f40cdc)

(this dialog is only displayed when toggling a file from private to public)

A toast is then displayed: 

![Screenshot 2024-05-15 at 4 39 19 PM](https://github.com/bcgov/bcbox/assets/103449568/5c714793-1e38-45b3-9ea4-68277304db33)

A toast is also displayed when toggling a file from public to private:

![Screenshot 2024-05-15 at 4 38 50 PM](https://github.com/bcgov/bcbox/assets/103449568/aca6a714-9424-45de-9e2e-dad315646ab9)

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3667

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
N/A