### PR TITLE
Bug fix: only fetch permissions for objects in table

### DIFF
--- a/frontend/src/components/object/ObjectTable.vue
+++ b/frontend/src/components/object/ObjectTable.vue
@@ -125,7 +125,9 @@ const loadLazyData = (event?: any) => {
     })
     // add object permissions to store
     .then((objects: Array<COMSObjectDataSource>) => {
-      permissionStore.fetchObjectPermissions({ objectId: objects.map((o: COMSObject) => o.id) });
+      if(objects.length > 0) {
+        permissionStore.fetchObjectPermissions({ objectId: objects.map((o: COMSObject) => o.id) });
+      }
     });
 };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

when loading object table, after fetching objects we fetch object permissions.
If folder is empty and there are no objects, the call to fetch object permissions searches perms for all objects in entire COMS db.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->