### PR TITLE
Allow child bucket sub-path to contains forward slashes

### DIFF
--- a/frontend/src/components/bucket/BucketChildConfig.vue
+++ b/frontend/src/components/bucket/BucketChildConfig.vue
@@ -102,17 +102,16 @@ const onCancel = () => {
       <TextInput
         name="subKey"
         label="Path"
-        placeholder="For example: '2024/January/documents'"
-        :help-text="`The relative path of the subfolder.<br />
-          You can choose a path that exists in your object storage or create a new one.<br />
-          Folder levels are supported using '/' between levels.<br />
-          This value cannot be changed after it is set.`"
+        placeholder="my-documents"
+        :help-text="`The relative path of the subfolder. You can pick a new path or choose an existing object storage path,
+          but it can't be changed after it is set.<br />
+          Folder levels are supported using '/' between levels (for example: 2024/January/my-documents).`"
         class="child-input"
       />
       <TextInput
         name="bucketName"
         label="Folder display name *"
-        placeholder="For example: 'My Documents'"
+        placeholder="My Documents"
         help-text="Your custom display name for the subfolder - any name as you would like to see it listed in BCBox."
         class="child-input"
         autofocus

--- a/frontend/src/components/bucket/BucketChildConfig.vue
+++ b/frontend/src/components/bucket/BucketChildConfig.vue
@@ -26,8 +26,7 @@ const schema = object({
   bucketName: string().required().max(255).label('Folder display name'),
   subKey: string()
     .required()
-    .matches(/^[^\\]+$/, 'Folder sub-path must not contain back slashes')
-    .label('Folder sub-path')
+    .matches(/^[^\\]+$/, { excludeEmptyString: true, message: 'Path must not contain backslashes' })
 });
 
 // Actions
@@ -102,17 +101,20 @@ const onCancel = () => {
       </Message>
       <TextInput
         name="subKey"
-        label="Folder sub-path"
-        placeholder="my-documents"
-        help-text="The directory will be created if it does not already exist.
-          Sub-paths are supported using '/' between levels.
-          This value cannot be changed after it is set."
+        label="Path"
+        placeholder="For example: '2024/January/documents'"
+        :help-text="`The relative path of the subfolder.<br />
+          You can choose a path that exists in your object storage or create a new one.<br />
+          Folder levels are supported using '/' between levels.<br />
+          This value cannot be changed after it is set.`"
+        class="child-input"
       />
       <TextInput
         name="bucketName"
         label="Folder display name *"
-        placeholder="My Documents"
+        placeholder="For example: 'My Documents'"
         help-text="Your custom display name for the subfolder - any name as you would like to see it listed in BCBox."
+        class="child-input"
         autofocus
       />
       <Button
@@ -128,3 +130,8 @@ const onCancel = () => {
     </Form>
   </Dialog>
 </template>
+<style scoped lang="scss">
+.child-input:deep(input) {
+  width: 70%;
+}
+</style>

--- a/frontend/src/components/bucket/BucketChildConfig.vue
+++ b/frontend/src/components/bucket/BucketChildConfig.vue
@@ -26,7 +26,7 @@ const schema = object({
   bucketName: string().required().max(255).label('Folder display name'),
   subKey: string()
     .required()
-    .matches(/^[^/\\]+$/, 'Folder sub-path must not contain back or forward slashes')
+    .matches(/^[^\\]+$/, 'Folder sub-path must not contain back slashes')
     .label('Folder sub-path')
 });
 

--- a/frontend/src/components/bucket/BucketConfigForm.vue
+++ b/frontend/src/components/bucket/BucketConfigForm.vue
@@ -122,7 +122,7 @@ const onCancel = () => {
       <TextInput
         name="bucketName"
         label="Folder name *"
-        placeholder="For example: 'My Documents'"
+        placeholder="My Documents"
         help-text="Your custom display name for the storage location,
           shown in BCBox as a folder. Any name as you would like to see it listed in BCBox."
         autofocus
@@ -130,13 +130,13 @@ const onCancel = () => {
       <TextInput
         name="bucket"
         label="Bucket *"
-        placeholder="For example: 'wildfire_bucket'"
+        placeholder="bucket0123456789"
         :help-text="'The name of the bucket given to you. For example: \'yxwgj\'.'"
       />
       <TextInput
         name="endpoint"
         label="Endpoint *"
-        placeholder="For example: 'https://nrs.objectstore.gov.bc.ca'"
+        placeholder="https://example.com"
         help-text="The URL of your object storage namespace without the bucket identifier/name."
       />
       <Password
@@ -154,11 +154,10 @@ const onCancel = () => {
       <TextInput
         name="key"
         label="Path"
-        placeholder="For example: '/maps/bc'"
-        help-text="Optionally mount the storage location source to be mounted at a specific subfolder<br />
-          The folder will be created if it does not already exist.<br />
-          This will default to the root '/' if not provided.<br />
-          This value cannot be changed after the storage location source is configured."
+        placeholder="/"
+        help-text="Optionally mounts the storage location at a specific path.
+          A folder will be created if it does not already exist.<br />
+          This will default to the root '/' if not provided."
         :disabled="!!props.bucket"
       />
       <Button

--- a/frontend/src/components/bucket/BucketConfigForm.vue
+++ b/frontend/src/components/bucket/BucketConfigForm.vue
@@ -53,9 +53,8 @@ const schema = object({
   bucketName: string().max(255).required().label('Folder name'),
   endpoint: string().max(255).required().label('Endpoint'),
   key: string()
-    .matches(/^[^\\]+$/, 'Sub-path must not contain backslashes')
-    .max(255)
-    .label('Key'),
+    .matches(/^[^\\]+$/, { excludeEmptyString: true, message: 'Path must not contain backslashes' })
+    .max(255),
   secretAccessKey: string().max(255).required().label('Secret Access Key')
 });
 
@@ -99,8 +98,9 @@ const onSubmit = async (values: any) => {
     toast.success('Configuring storage location source', 'Configuration successful');
 
     if ((bucketChanges.accessKeyId || bucketChanges.secretAccessKey) && hasChildren) {
-      toast.info('Child storage locations exist',
-        'Remember to update their credentials where applicable', { life: 10000 });
+      toast.info('Subfolders exist', 'Remember to update their credentials where applicable', {
+        life: 10000
+      });
     }
   } catch (error: any) {
     toast.error('Configuring storage location source', error);
@@ -122,7 +122,7 @@ const onCancel = () => {
       <TextInput
         name="bucketName"
         label="Folder name *"
-        placeholder="My Documents"
+        placeholder="For example: 'My Documents'"
         help-text="Your custom display name for the storage location,
           shown in BCBox as a folder. Any name as you would like to see it listed in BCBox."
         autofocus
@@ -130,13 +130,13 @@ const onCancel = () => {
       <TextInput
         name="bucket"
         label="Bucket *"
-        placeholder="bucket0123456789"
+        placeholder="For example: 'wildfire_bucket'"
         :help-text="'The name of the bucket given to you. For example: \'yxwgj\'.'"
       />
       <TextInput
         name="endpoint"
         label="Endpoint *"
-        placeholder="https://example.com/"
+        placeholder="For example: 'https://nrs.objectstore.gov.bc.ca'"
         help-text="The URL of your object storage namespace without the bucket identifier/name."
       />
       <Password
@@ -153,11 +153,11 @@ const onCancel = () => {
       />
       <TextInput
         name="key"
-        label="Sub-path"
-        placeholder="/"
-        help-text="Optionally sets the bucket storage location source to mount at a specific subdirectory / subfolder.
-          The directory will be created if it does not already exist.
-          This will default to the root '/' if not provided.
+        label="Path"
+        placeholder="For example: '/maps/bc'"
+        help-text="Optionally mount the storage location source to be mounted at a specific subfolder<br />
+          The folder will be created if it does not already exist.<br />
+          This will default to the root '/' if not provided.<br />
           This value cannot be changed after the storage location source is configured."
         :disabled="!!props.bucket"
       />

--- a/frontend/src/components/form/TextInput.vue
+++ b/frontend/src/components/form/TextInput.vue
@@ -35,7 +35,8 @@ const { errorMessage, value } = useField<string>(toRef(props, 'name'));
       :class="{ 'p-invalid': errorMessage }"
       :disabled="disabled"
     />
-    <small :id="`${name}-help`">{{ helpText }}</small>
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <small :id="`${name}-help`"><span v-html="helpText" /></small>
     <ErrorMessage :name="name" />
   </div>
 </template>

--- a/frontend/src/views/list/ListObjectsView.vue
+++ b/frontend/src/views/list/ListObjectsView.vue
@@ -53,7 +53,6 @@ onBeforeMount(async () => {
 
 <template>
   <div v-if="ready">
-    <h1>Files</h1>
     <h2
       v-if="bucket"
       class="mb-3 flex overflow-hidden"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
When adding adding a sub-folder, allow user to enter a path that traverses multiple folder levels.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->