### PR TITLE
Show results of bulk invite and add/remove in table

### DIFF
--- a/frontend/src/assets/variables.scss
+++ b/frontend/src/assets/variables.scss
@@ -11,7 +11,9 @@ $bcbox-primary: #036;
 $bcbox-link-text: #1a5a96;
 $bcbox-link-text-hover: #2378c7;
 $bcbox-outline-on-primary: #fff;
+$bcbox-success: #2e8540;
 $bcbox-error: #d8292f;
+$bcbox-noaction: #606060;
 
 // highlighted sections, table rows
 $bcbox-highlight-background: #d9e1e8;

--- a/frontend/src/components/common/BulkPermissionResults.vue
+++ b/frontend/src/components/common/BulkPermissionResults.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
-import { Dialog } from '@/lib/primevue';
+import { ref } from 'vue';
+import { Column, DataTable, Dialog } from '@/lib/primevue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
 // Props
 type Props = {
   results: Array<Object>;
   resource: any;
   resourceType: string;
 };
-const props = withDefaults(defineProps<Props>(), {});
+
+const props = withDefaults(defineProps<Props>(), {
+  results: undefined
+});
 
 const modelValue = defineModel<boolean>({ default: false });
 </script>
@@ -16,6 +22,58 @@ const modelValue = defineModel<boolean>({ default: false });
     header="Results"
     :modal="true"
   >
-    <pre>{{ props.results }}</pre>
+    <DataTable
+      :value="props.results"
+      class="p-datatable-striped"
+    >
+      <Column
+        field="email"
+        header="Email"
+      />
+      <Column
+        field="description"
+        header="Result"
+      >
+        <template #body="{ data }">
+          <span>
+            <span class="m-1">
+              <font-awesome-icon
+                v-if="data.status === 1"
+                icon="fa-circle-check"
+                class="icon-success"
+              />
+              <font-awesome-icon
+                v-else-if="data.status === 0"
+                icon="fa-circle-minus"
+                class="icon-noaction"
+              />
+              <!--
+                Errors aren't really returned at the moment
+                  (e.g. CHES doesn't return emailing errors)
+                so errors won't ever appear here (yet!).
+              -->
+              <font-awesome-icon
+                v-else
+                icon="fa-circle-xmark"
+                class="icon-error"
+              />
+            </span>
+            {{ data.description }}
+          </span>
+        </template>
+      </Column>
+    </DataTable>
   </Dialog>
 </template>
+
+<style scoped lang="scss">
+.icon-success {
+  color: $bcbox-success;
+}
+.icon-error {
+  color: $bcbox-error;
+}
+.icon-noaction {
+  color: $bcbox-noaction;
+}
+</style>

--- a/frontend/src/components/common/BulkPermissionResults.vue
+++ b/frontend/src/components/common/BulkPermissionResults.vue
@@ -15,6 +15,13 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const modelValue = defineModel<boolean>({ default: false });
+
+// Exports DataTable results
+const batchResults = ref();
+
+const exportCSV = (event: any) => {
+  batchResults.value.exportCSV();
+};
 </script>
 <template>
   <Dialog
@@ -23,9 +30,24 @@ const modelValue = defineModel<boolean>({ default: false });
     :modal="true"
   >
     <DataTable
+      ref="batchResults"
+      :export-filename="`${resourceType === 'object' ? resource.name.replace(/\.[^/.]+$/, '') : resource.bucketName}_bulk_results`"
       :value="props.results"
       class="p-datatable-striped"
     >
+      <div class="action-buttons">
+        <Button
+          v-tooltip.bottom="'Save results'"
+          aria-label="Save results"
+          class="p-button"
+          @click="exportCSV($event)"
+        >
+          <font-awesome-icon
+            icon="fa-download"
+            class="pl-1 pr-1 pt-1 pb-1"
+          />
+        </Button>
+      </div>
       <Column
         field="email"
         header="Email"
@@ -47,11 +69,6 @@ const modelValue = defineModel<boolean>({ default: false });
                 icon="fa-circle-minus"
                 class="icon-noaction"
               />
-              <!--
-                Errors aren't really returned at the moment
-                  (e.g. CHES doesn't return emailing errors)
-                so errors won't ever appear here (yet!).
-              -->
               <font-awesome-icon
                 v-else
                 icon="fa-circle-xmark"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
<!-- Describe your changes in detail -->
This PR adds a `DataTable` (contained inside a modal) displaying the results of a bulk operation (i.e. add/remove permissions, sending invites). This is displayed after the user clicks "Submit" and all operations are complete.

Each operation is displayed as one of 3 possible result types:
* Success (green checkmark) - operation was successful
* No action (grey minus sign) - no action was performed (e.g. permission already exists on user)
* Failure (red "X") - fail (see "further comments" at bottom)

The actual bulk operations were implemented in #212, though the results weren't displayed in a user-friendly table.

The contents of this `DataTable` can also be downloaded as a CSV file.

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3677
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3679

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Given how bulk add/remove/invite works at the moment, there will never be errors to display:
* CHES does not return any emailing-related errors (e.g. if the receiving address rejects the email). 
* Improperly-formatted email addresses (i.e. RFC 5322 non-compliant) are already caught by the form validation before the CHES API call is amde.
* The parts of the UI for bulk add/remove/invite permissions are already inaccessible if the user doesn't have the required permissions, so insufficient user permissions should not be an issue.