### PR TITLE
Bulk results modal: change "save results" icon to match BCBox style

### DIFF
--- a/frontend/src/components/common/BulkPermissionResults.vue
+++ b/frontend/src/components/common/BulkPermissionResults.vue
@@ -19,7 +19,7 @@ const modelValue = defineModel<boolean>({ default: false });
 // Exports DataTable results
 const batchResults = ref();
 
-const exportCSV = (event: any) => {
+const exportCSV = () => {
   batchResults.value.exportCSV();
 };
 </script>
@@ -39,13 +39,10 @@ const exportCSV = (event: any) => {
         <Button
           v-tooltip.bottom="'Save results'"
           aria-label="Save results"
-          class="p-button"
-          @click="exportCSV($event)"
+          class="p-button p-button-text"
+          @click="exportCSV()"
         >
-          <font-awesome-icon
-            icon="fa-download"
-            class="pl-1 pr-1 pt-1 pb-1"
-          />
+          <font-awesome-icon icon="fas fa-download" />
         </Button>
       </div>
       <Column


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
<!-- Describe your changes in detail -->
This tweaks the styling of the "save results" button icon for the bulk results modal, so that it matches the style throughout the rest of BCBox (i.e. blue icon with no background). Previously, it was a white icon on a blue button.

This also removes the unneeded argument in `exportCSV()`, as mentioned in https://github.com/bcgov/bcbox/pull/215#discussion_r1644943689.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3679

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
In the interest of time, #215 was pushed to production without these fixes. The current PR is a minor continuation and includes them.