### PR TITLE
Add Navigation to Delete button

### DIFF
--- a/frontend/src/components/bucket/BucketTable.vue
+++ b/frontend/src/components/bucket/BucketTable.vue
@@ -65,6 +65,7 @@ const showPermissions = async (bucketId: string, bucketName: string) => {
 };
 
 const confirmDeleteBucket = (bucketId: string) => {
+  focusedElement.value = document.activeElement;
   confirm.require({
     message:
       'Are you sure you want to delete this folder in BCBox? \
@@ -73,7 +74,9 @@ const confirmDeleteBucket = (bucketId: string) => {
     header: 'Delete folder',
     acceptLabel: 'Confirm',
     rejectLabel: 'Cancel',
-    accept: () => deleteBucket(bucketId)
+    accept: () => deleteBucket(bucketId),
+    onHide: () => onDialogHide(),
+    reject: () => onDialogHide()
   });
 };
 
@@ -344,7 +347,6 @@ watch(getBuckets, () => {
             class="p-button-lg p-button-text p-button-danger"
             aria-label="Delete folder"
             @click="confirmDeleteBucket(node.data.bucketId)"
-            @keyup.enter="confirmDeleteBucket(node.data.bucketId)"
           >
             <font-awesome-icon icon="fa-solid fa-trash" />
           </Button>

--- a/frontend/src/components/object/DeleteObjectButton.vue
+++ b/frontend/src/components/object/DeleteObjectButton.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import { storeToRefs } from 'pinia';
 import { ref } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 import { Button, Dialog, useConfirm } from '@/lib/primevue';
-import { useObjectStore } from '@/store/objectStore';
+import { useNavStore, useObjectStore } from '@/store';
 import { ButtonMode } from '@/utils/enums';
+import { onDialogHide } from '@/utils/utils';
 
 // Props
 type Props = {
@@ -23,6 +25,7 @@ const emit = defineEmits(['on-deleted-success', 'on-deleted-error']);
 
 // Store
 const objectStore = useObjectStore();
+const { focusedElement } = storeToRefs(useNavStore());
 
 // State
 const displayNoFileDialog = ref(false);
@@ -31,6 +34,7 @@ const displayNoFileDialog = ref(false);
 const confirm = useConfirm();
 
 const confirmDelete = () => {
+  focusedElement.value = document.activeElement;
   if (props.ids.length) {
     const item = props.versionId ? 'version' : 'object';
     const msgContext = props.ids.length > 1 ? `the selected ${props.ids.length} ${item}s` : `this ${item}`;
@@ -46,7 +50,9 @@ const confirmDelete = () => {
             .then(() => emit('on-deleted-success', props.versionId))
             .catch(() => {});
         });
-      }
+      },
+      onHide: () => onDialogHide(),
+      reject: () => onDialogHide()
     });
   } else {
     displayNoFileDialog.value = true;


### PR DESCRIPTION
Focus should be the entire popup box and it should read out entire content
Focus should go back to the details icon button once close is hit
[
SC3689](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3689)

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->