### PR TITLE
Bulk results modal: tweak DataTable styling

### DIFF
--- a/frontend/src/components/common/BulkPermission.vue
+++ b/frontend/src/components/common/BulkPermission.vue
@@ -408,6 +408,4 @@ const onSubmit = handleSubmit(async (values: any, { resetForm }) => {
     :resource="resource"
     :resource-type="resourceType"
   />
-
-  <pre v-if="complete">{{ results }}</pre>
 </template>

--- a/frontend/src/components/common/BulkPermissionResults.vue
+++ b/frontend/src/components/common/BulkPermissionResults.vue
@@ -16,6 +16,11 @@ const props = withDefaults(defineProps<Props>(), {
 
 const modelValue = defineModel<boolean>({ default: false });
 
+const exportFileName =
+  props.resourceType === 'object'
+    ? props.resource.name.replace(/\.[^/.]+$/, '')
+    : `${props.resource.bucketName}_bulk_results`;
+
 // Exports DataTable results
 const batchResults = ref();
 
@@ -31,9 +36,9 @@ const exportCSV = () => {
   >
     <DataTable
       ref="batchResults"
-      :export-filename="`${resourceType === 'object' ? resource.name.replace(/\.[^/.]+$/, '') : resource.bucketName}_bulk_results`"
+      :export-filename="exportFileName"
       :value="props.results"
-      class="p-datatable-striped"
+      class="p-datatable-striped results-modal-table"
     >
       <div class="action-buttons">
         <Button
@@ -54,7 +59,7 @@ const exportCSV = () => {
         header="Result"
       >
         <template #body="{ data }">
-          <span>
+          <span class="mr-3">
             <span class="m-1">
               <font-awesome-icon
                 v-if="data.status === 1"
@@ -89,5 +94,10 @@ const exportCSV = () => {
 }
 .icon-noaction {
   color: $bcbox-noaction;
+}
+
+.results-modal-table {
+  text-wrap: nowrap;
+  min-width: 35em;
 }
 </style>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This fixes the styling for the bulk results modal/table.

Previously:
* Long email/results strings would wrap
* Spacing was inadequate along the right side of the results column
* The table/modal would be to narrow if the results string for all emails is short 

Also, the `DataTable`'s `export-filename` declaration was too lengthy, so it has been moved to a separate line.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
N/A