### PR TITLE
Error toasts: show HTTP response detail + don't auto-close

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -39,7 +39,7 @@ onBeforeUnmount(() => {
 // Top level error handler
 onErrorCaptured((e: Error) => {
   const toast = useToast();
-  toast.error('Error', e.message);
+  toast.error('Error', e.message, { life: 0 });
 });
 </script>
 

--- a/frontend/src/components/bucket/BucketConfigForm.vue
+++ b/frontend/src/components/bucket/BucketConfigForm.vue
@@ -86,7 +86,7 @@ const onSubmit = async (values: any) => {
       : await bucketStore.createBucket(formBucket);
 
     // if successfully added a new configuration, do a recursive sync of this bucket
-    if(!props.bucket) await bucketStore.syncBucket(bucketModel.bucketId, true);
+    if (!props.bucket) await bucketStore.syncBucket(bucketModel.bucketId, true);
     // refresh bucket list
     await bucketStore.fetchBuckets({ userId: getUserId.value, objectPerms: true });
 
@@ -109,7 +109,7 @@ const onSubmit = async (values: any) => {
       });
     }
   } catch (error: any) {
-    toast.error('Configuring storage location source', error);
+    toast.error('Configuring storage location source', error.response?.data.detail ?? error, { life: 0 });
   }
 };
 
@@ -186,7 +186,7 @@ const onCancel = () => {
         :bucket-id="bucket?.bucketId"
         :mode="ButtonMode.BUTTON"
         :recursive="true"
-        />
+      />
     </Form>
   </div>
 </template>

--- a/frontend/src/components/common/BulkPermission.vue
+++ b/frontend/src/components/common/BulkPermission.vue
@@ -220,7 +220,7 @@ const onSubmit = handleSubmit(async (values: any, { resetForm }) => {
     complete.value = true;
     resetForm();
   } catch (error: any) {
-    toast.error('Bulk permission operation failed', error.response?.data.detail, { life: 0 });
+    toast.error('Bulk permission operation failed', error.response?.data.detail ?? error, { life: 0 });
   }
   loading.value = false;
 });

--- a/frontend/src/components/common/Invite.vue
+++ b/frontend/src/components/common/Invite.vue
@@ -194,7 +194,7 @@ const onSubmit = handleSubmit(async (values: any, { resetForm }) => {
     complete.value = true;
     resetForm();
   } catch (error: any) {
-    toast.error('Creating Invite', error.response?.data.detail, { life: 0 });
+    toast.error('Creating Invite', error.response?.data.detail ?? error, { life: 0 });
   }
   loading.value = false;
 });

--- a/frontend/src/components/common/SyncButton.vue
+++ b/frontend/src/components/common/SyncButton.vue
@@ -51,7 +51,7 @@ const onSubmit = () => {
   } else if (props.bucketId && props.recursive) {
     bucketStore.syncBucket(props.bucketId, true);
   } else {
-    toast.error('', 'Unable to synchronize');
+    toast.error('', 'Unable to synchronize', { life: 0 });
   }
 
   displaySyncDialog.value = false;
@@ -122,8 +122,9 @@ const onClick = () => {
     <ul class="mb-4 ml-1.5">
       <!-- recursive bucket-->
       <li v-if="props.bucketId && props.recursive">
-        This will schedule a <strong>Full</strong> synchronization of all files
-        and any sub-folders with the source storage location.
+        This will schedule a
+        <strong>Full</strong>
+        synchronization of all files and any sub-folders with the source storage location.
       </li>
       <!-- flat bucket -->
       <li v-else-if="props.bucketId">
@@ -161,7 +162,6 @@ const onClick = () => {
   <span class="material-icons-outlined">sync</span>
   </Button> -->
 
-
   <Button
     v-if="props.mode === ButtonMode.ICON"
     v-tooltip.bottom="{ value: labelText }"
@@ -170,7 +170,7 @@ const onClick = () => {
     :aria-label="labelText"
     @click="onClick"
   >
-  <span class="material-icons-outlined">sync</span>
+    <span class="material-icons-outlined">sync</span>
   </Button>
   <Button
     v-else
@@ -180,7 +180,7 @@ const onClick = () => {
     :aria-label="labelText"
     @click="onClick"
   >
-  <span class="material-icons-outlined mr-1 sync-icon">sync</span>
+    <span class="material-icons-outlined mr-1 sync-icon">sync</span>
     Sync
   </Button>
 </template>

--- a/frontend/src/components/object/DeleteObjectButton.vue
+++ b/frontend/src/components/object/DeleteObjectButton.vue
@@ -2,7 +2,7 @@
 import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 
-import { Button, Dialog, useConfirm, useToast} from '@/lib/primevue';
+import { Button, Dialog, useConfirm, useToast } from '@/lib/primevue';
 import { useNavStore, useObjectStore, useVersionStore } from '@/store';
 import { ButtonMode } from '@/utils/enums';
 import { onDialogHide } from '@/utils/utils';
@@ -13,7 +13,7 @@ type Props = {
   ids: Array<string>;
   mode: ButtonMode;
   versionId?: string; // Only use this when deleting a single object
-  hardDelete?: boolean // are we doing a hardDelete delete?
+  hardDelete?: boolean; // are we doing a hardDelete delete?
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -47,7 +47,7 @@ const confirmDelete = async () => {
     // refresh version store to determine if bucketVersioningEnabled
     await versionStore.fetchVersions({ objectId: props.ids[0] });
     // if versionId provided, and versioning is enabled on bucket, delete version
-    if(props.versionId && bucketVersioningEnabled.value) {
+    if (props.versionId && bucketVersioningEnabled.value) {
       confirm.require({
         message: 'Are you sure you want to permanently delete this version?',
         header: 'Delete Version?',
@@ -58,9 +58,8 @@ const confirmDelete = async () => {
             await objectStore.deleteVersion(props.ids[0], props.versionId);
             emit('on-version-deleted', { versionId: props.versionId });
             toast.success('Version deleted');
-          }
-          catch (error) {
-            toast.error('Unable to delete version');
+          } catch (error: any) {
+            toast.error('Unable to delete version', error.response?.data.detail ?? error, { life: 0 });
           }
         },
         onHide: () => onDialogHide(),
@@ -72,13 +71,13 @@ const confirmDelete = async () => {
       const isPermanent = props.hardDelete || !bucketVersioningEnabled.value;
       const msgContext = numberOfObjects > 1 ? `the selected ${numberOfObjects} files` : 'this file';
       let header, message;
-      if(!isPermanent){
-        header =`Delete ${numberOfObjects > 1 ? 'files' : 'file'}?`,
-        message =  `Are you sure you want to delete ${msgContext}?
+      if (!isPermanent) {
+        header = `Delete ${numberOfObjects > 1 ? 'files' : 'file'}?`,
+        message = `Are you sure you want to delete ${msgContext}?
           If Versioning is enabled on the object storage server, deleted files are moved to the Recycle Bin`;
       } else {
-        header =`Permanently Delete ${numberOfObjects > 1 ? 'files' : 'file'}?`,
-        message =  `This action cannot be undone. Are you sure you want to permanently delete ${msgContext}.
+        header = `Permanently Delete ${numberOfObjects > 1 ? 'files' : 'file'}?`,
+        message = `This action cannot be undone. Are you sure you want to permanently delete ${msgContext}.
           Once deleted, these files cannot be restored`;
       }
       confirm.require({
@@ -90,31 +89,32 @@ const confirmDelete = async () => {
           try {
             for (const id of props.ids) {
               await objectStore.deleteObject(id, props.hardDelete);
-            };
+            }
             // to break on single failure (use promise.all ?)
             toast.success(`${numberOfObjects} ${numberOfObjects > 1 ? 'files' : 'file'} deleted`);
             emit('on-object-deleted', { hardDelete: props.hardDelete });
-          }
-          catch (error) {
-            toast.error('Unable to delete File(s)');
+          } catch (error: any) {
+            toast.error('Unable to delete File(s)', error.response?.data.detail ?? error, { life: 0 });
           }
         },
         onHide: () => onDialogHide(),
         reject: () => onDialogHide()
       });
     }
-  }
-
-  else {
+  } else {
     displayNoFileDialog.value = true;
   }
 };
 const buttonLabel = computed(() => {
-  return props.hardDelete ?
-    (props.versionId ?
-      'Permanently delete version' : (props.ids.length > 1 ?
-        'Permanently delete selected files' : 'Permanently delete file')) :
-    (props.versionId ? 'Delete version' : 'Delete file' );
+  return props.hardDelete
+    ? props.versionId
+      ? 'Permanently delete version'
+      : props.ids.length > 1
+        ? 'Permanently delete selected files'
+        : 'Permanently delete file'
+    : props.versionId
+      ? 'Delete version'
+      : 'Delete file';
 });
 </script>
 
@@ -142,7 +142,7 @@ const buttonLabel = computed(() => {
     :aria-label="buttonLabel"
     @click="confirmDelete()"
   >
-  <span class="material-icons-outlined">delete</span>
+    <span class="material-icons-outlined">delete</span>
   </Button>
   <Button
     v-else
@@ -152,7 +152,7 @@ const buttonLabel = computed(() => {
     :aria-label="buttonLabel"
     @click="confirmDelete()"
   >
-  <span class="material-icons-outlined mr-1">delete</span>
+    <span class="material-icons-outlined mr-1">delete</span>
     Delete
   </Button>
 </template>

--- a/frontend/src/components/object/ObjectMetadataTagForm.vue
+++ b/frontend/src/components/object/ObjectMetadataTagForm.vue
@@ -53,7 +53,7 @@ const onSubmit = async (values: any) => {
       tagset: values.tagset
     } as ObjectMetadataTagFormType);
   } catch (error: any) {
-    toast.error('Adding metadata and tags', error);
+    toast.error('Adding metadata and tags', error.response?.data.detail ?? error, { life: 0 });
   }
 };
 

--- a/frontend/src/components/object/ObjectPublicToggle.vue
+++ b/frontend/src/components/object/ObjectPublicToggle.vue
@@ -44,7 +44,7 @@ const togglePublic = async (setPublicValue: boolean) => {
           .then(() => {
             toast.success(`"${props.objectName}" set to public`);
           })
-          .catch((e) => toast.error(e));
+          .catch((e) => toast.error('Setting file to public', e.response?.data.detail, { life: 0 }));
       },
       reject: () => (isPublic.value = false),
       onHide: () => (isPublic.value = false)
@@ -55,7 +55,7 @@ const togglePublic = async (setPublicValue: boolean) => {
       .then(() => {
         toast.success(`"${props.objectName}" is no longer public`);
       })
-      .catch((e) => toast.error(e));
+      .catch((e) => toast.error('Setting file to non-public', e.response?.data.detail, { life: 0 }));
 };
 
 watch(props, () => {

--- a/frontend/src/components/object/ObjectUpload.vue
+++ b/frontend/src/components/object/ObjectUpload.vue
@@ -63,12 +63,11 @@ const onUpload = async (event: any) => {
           );
 
           // show toast for any object updates
-          if (response?.newVersionId) toast.info(
-            `A new version of file '${file.name}' has been created`);
+          if (response?.newVersionId) toast.info(`A new version of file '${file.name}' has been created`);
 
           successfulFiles.value.push(file);
         } catch (error: any) {
-          toast.error(`Failed to upload file ${file.name}`, error, { life: 0 });
+          toast.error(`Failed to upload file ${file.name}`, error.response?.data.detail ?? error, { life: 0 });
           failedFiles.value.push(file);
         } finally {
           appStore.endUploading();
@@ -85,7 +84,7 @@ const onUpload = async (event: any) => {
     // Update object store
     await objectStore.fetchObjects({ bucketId: bucketId, userId: getUserId.value, bucketPerms: true });
   } else {
-    toast.error('Updating file', 'Failed to acquire bucket ID');
+    toast.error('Updating file', 'Failed to acquire bucket ID', { life: 0 });
   }
 };
 

--- a/frontend/src/components/object/ObjectUploadBasic.vue
+++ b/frontend/src/components/object/ObjectUploadBasic.vue
@@ -98,7 +98,7 @@ const onUpload = async () => {
     }
   } catch (error: any) {
     appStore.endUploading();
-    toast.error(`File upload: ${file.value?.name}`, error);
+    toast.error(`File upload: ${file.value?.name}`, error.response?.data.detail ?? error, { life: 0 });
   }
 };
 

--- a/frontend/src/components/object/RestoreObjectButton.vue
+++ b/frontend/src/components/object/RestoreObjectButton.vue
@@ -38,8 +38,7 @@ const confirmRestore = () => {
   focusedElement.value = document.activeElement;
   const numberOfObjects = props.ids.length;
   if (numberOfObjects) {
-
-    if(props.versionId) {
+    if (props.versionId) {
       confirm.require({
         message: 'Are you sure you want to restore the file with the this version?',
         header: 'Restore Version?',
@@ -50,26 +49,22 @@ const confirmRestore = () => {
             const newVersion = await objectStore.restoreObject(props.ids[0], props.versionId);
             emit('on-version-restored', { versionId: newVersion.data.id });
             toast.success('Version restored');
-          }
-          catch (error) {
-            toast.error('Unable to restore version');
+          } catch (error: any) {
+            toast.error('Unable to restore version', error.response?.data.detail ?? error, { life: 0 });
           }
         },
         onHide: () => onDialogHide(),
         reject: () => onDialogHide()
       });
-
-    }
-
-    else{
+    } else {
       let header: string, message: string, confirmation: string;
       const filename = getObject.value(props.ids[0])?.name;
-      if(numberOfObjects > 1) {
+      if (numberOfObjects > 1) {
         header = 'Restore Files?';
         message = `Are you sure you want to restore the selected ${numberOfObjects} files from the Recycle Bin?
           Once restored, the files will be returned to their original location.`;
         confirmation = `${numberOfObjects} have been successfully restored to their original location.`;
-      } else{
+      } else {
         header = 'Restore File?';
         message = `Are you sure you want to restore this file from the Recycle Bin?
           Once restored, the file will be returned to its original location.`;
@@ -86,18 +81,15 @@ const confirmRestore = () => {
             for (const id of props.ids) {
               await objectStore.restoreObject(id, undefined);
             }
-            toast.success(`${numberOfObjects > 1 ? 'Files' : 'File'} Restored`,
-              confirmation );
+            toast.success(`${numberOfObjects > 1 ? 'Files' : 'File'} Restored`, confirmation);
             emit('on-object-restored');
-          }
-          catch (error) {
-            toast.error('Unable to restore file');
+          } catch (error: any) {
+            toast.error('Unable to restore file', error.response?.data.detail ?? error, { life: 0 });
           }
         },
         onHide: () => onDialogHide(),
         reject: () => onDialogHide()
       });
-
     }
   } else {
     displayNoFileDialog.value = true;
@@ -129,7 +121,7 @@ const confirmRestore = () => {
     :aria-label="props.versionId ? 'Restore this version' : 'Restore latest version'"
     @click="confirmRestore()"
   >
-  <span class="material-icons-outlined">restore</span>
+    <span class="material-icons-outlined">restore</span>
   </Button>
   <Button
     v-else

--- a/frontend/src/store/bucketStore.ts
+++ b/frontend/src/store/bucketStore.ts
@@ -51,13 +51,13 @@ export const useBucketStore = defineStore('bucket', () => {
     }
   }
 
-  async function deleteBucket(bucketId: string, recursive: boolean){
+  async function deleteBucket(bucketId: string, recursive: boolean) {
     try {
       appStore.beginIndeterminateLoading();
-      await bucketService.deleteBucket(bucketId, recursive );
+      await bucketService.deleteBucket(bucketId, recursive);
       toast.success('', 'Folder deleted');
     } catch (error: any) {
-      toast.error('Unable to delete folder', error);
+      toast.error('Unable to delete folder', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -98,7 +98,7 @@ export const useBucketStore = defineStore('bucket', () => {
         return response;
       } else return [];
     } catch (error: any) {
-      toast.error('Fetching buckets', error);
+      toast.error('Fetching buckets', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -118,10 +118,10 @@ export const useBucketStore = defineStore('bucket', () => {
     try {
       appStore.beginIndeterminateLoading();
 
-      await bucketService.syncBucket(bucketId, recursive );
+      await bucketService.syncBucket(bucketId, recursive);
       toast.success('', 'Sync is in queue and will begin soon');
     } catch (error: any) {
-      toast.error('Unable to sync', error);
+      toast.error('Unable to sync', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }

--- a/frontend/src/store/metadataStore.ts
+++ b/frontend/src/store/metadataStore.ts
@@ -51,7 +51,7 @@ export const useMetadataStore = defineStore('metadata', () => {
       // Merge and assign
       state.metadata.value = difference.concat(response);
     } catch (error: any) {
-      toast.error('Fetching metadata', error);
+      toast.error('Fetching metadata', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -80,7 +80,7 @@ export const useMetadataStore = defineStore('metadata', () => {
       await objectService.replaceMetadata(objectId, metadata, versionId);
       await fetchMetadata({ objectId: objectId });
     } catch (error: any) {
-      toast.error('Updating metadata', error);
+      toast.error('Updating metadata', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -92,7 +92,7 @@ export const useMetadataStore = defineStore('metadata', () => {
       const response = (await objectService.searchMetadata({ metadata: metadataSet }, bucketId)).data;
       state.metadataSearchResults.value = response;
     } catch (error: any) {
-      toast.error('Searching metadata', error);
+      toast.error('Searching metadata', error.response?.data.detail ?? error, { life: 0 });
     }
   }
 

--- a/frontend/src/store/objectStore.ts
+++ b/frontend/src/store/objectStore.ts
@@ -51,7 +51,7 @@ export const useObjectStore = defineStore('object', () => {
     },
     axiosOptions?: AxiosRequestConfig
   ) {
-    try{
+    try {
       appStore.beginIndeterminateLoading();
 
       // Ensure x-amz-meta- prefix exists
@@ -64,10 +64,9 @@ export const useObjectStore = defineStore('object', () => {
       }
 
       await objectService.createObject(object, headers, params, axiosOptions);
-    }
-    // if file already exists in bucket do updateObject operation instead
-    catch(error: any) {
-      if (error.response?.status === 409){
+    } catch (error: any) {
+      // if file already exists in bucket do updateObject operation instead
+      if (error.response?.status === 409) {
         const newVersionId = await updateObject(
           error.response.data.existingObjectId,
           object,
@@ -76,8 +75,7 @@ export const useObjectStore = defineStore('object', () => {
           axiosOptions
         );
         return { newVersionId: newVersionId };
-      }
-      else {
+      } else {
         throw new Error('Network error');
       }
     } finally {
@@ -89,7 +87,7 @@ export const useObjectStore = defineStore('object', () => {
     try {
       appStore.beginIndeterminateLoading();
       // if doing hard delete, delete all versions of the object
-      if(hard) {
+      if (hard) {
         await versionStore.fetchVersions({ objectId: objectId });
         const versions = await versionStore.getVersionsByObjectId(objectId);
         for (const v of versions) {
@@ -97,10 +95,11 @@ export const useObjectStore = defineStore('object', () => {
         }
       }
       // else delete object (creates delete-marker)
-      else { await objectService.deleteObject(objectId); }
+      else {
+        await objectService.deleteObject(objectId);
+      }
       removeSelectedObject(objectId);
-    }
-    finally {
+    } finally {
       appStore.endIndeterminateLoading();
     }
   }
@@ -130,7 +129,7 @@ export const useObjectStore = defineStore('object', () => {
       appStore.beginIndeterminateLoading();
       return objectService.getObject(objectId, versionId).then((response) => response.data);
     } catch (error: any) {
-      toast.error('Downloading object', error);
+      toast.error('Downloading object', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -180,7 +179,7 @@ export const useObjectStore = defineStore('object', () => {
                 limit: params.limit ? params.limit : 50,
                 sort: params.sort ? params.sort : 'updatedAt',
                 order: params.order ? params.order : 'desc',
-                page: params.page ? params.page : 1,
+                page: params.page ? params.page : 1
               },
               headers
             )
@@ -208,7 +207,7 @@ export const useObjectStore = defineStore('object', () => {
         }
       }
     } catch (error: any) {
-      toast.error('Fetching objects', error);
+      toast.error('Fetching objects', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -248,7 +247,7 @@ export const useObjectStore = defineStore('object', () => {
       const obj = getters.getObject.value(objectId);
       if (obj) obj.public = isPublic;
     } catch (error: any) {
-      toast.error('Changing public state', error);
+      toast.error('Changing public state', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -280,7 +279,7 @@ export const useObjectStore = defineStore('object', () => {
       const newObject = await objectService.updateObject(objectId, object, headers, params, axiosOptions);
       return newObject.data.versionId;
     } catch (error: any) {
-      toast.error('Updating object', error);
+      toast.error('Updating object', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -292,7 +291,7 @@ export const useObjectStore = defineStore('object', () => {
       await objectService.syncObject(objectId);
       toast.success('', 'Sync is in queue and will begin soon');
     } catch (error: any) {
-      toast.error('Unable to sync', error);
+      toast.error('Unable to sync', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }

--- a/frontend/src/store/permissionStore.ts
+++ b/frontend/src/store/permissionStore.ts
@@ -58,7 +58,7 @@ export const usePermissionStore = defineStore('permission', () => {
       appStore.beginIndeterminateLoading();
       await permissionService.bucketAddPermissions(bucketId, [{ userId, permCode }]);
     } catch (error: any) {
-      toast.error('Adding bucket permission', error);
+      toast.error('Adding bucket permission', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       await fetchBucketPermissions({ bucketId: bucketId });
       await mapBucketToUserPermissions(bucketId);
@@ -70,7 +70,7 @@ export const usePermissionStore = defineStore('permission', () => {
     try {
       getters.getMappedBucketToUserPermissions.value.push(user);
     } catch (error: any) {
-      toast.error('Adding bucket user', error);
+      toast.error('Adding bucket user', error.response?.data.detail ?? error, { life: 0 });
     }
   }
 
@@ -79,7 +79,7 @@ export const usePermissionStore = defineStore('permission', () => {
       appStore.beginIndeterminateLoading();
       await permissionService.objectAddPermissions(objectId, [{ userId, permCode }]);
     } catch (error: any) {
-      toast.error('Adding object permission', error);
+      toast.error('Adding object permission', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       await fetchObjectPermissions({ objectId: objectId });
       await mapObjectToUserPermissions(objectId);
@@ -91,7 +91,7 @@ export const usePermissionStore = defineStore('permission', () => {
     try {
       getters.getMappedObjectToUserPermissions.value.push(user);
     } catch (error: any) {
-      toast.error('Adding object user', error);
+      toast.error('Adding object user', error.response?.data.detail ?? error, { life: 0 });
     }
   }
 
@@ -100,7 +100,7 @@ export const usePermissionStore = defineStore('permission', () => {
       appStore.beginIndeterminateLoading();
       await permissionService.bucketDeletePermission(bucketId, { userId, permCode });
     } catch (error: any) {
-      toast.error('Deleting bucket permission', error);
+      toast.error('Deleting bucket permission', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       await fetchBucketPermissions({ bucketId: bucketId });
       await mapBucketToUserPermissions(bucketId);
@@ -113,7 +113,7 @@ export const usePermissionStore = defineStore('permission', () => {
       appStore.beginIndeterminateLoading();
       await permissionService.objectDeletePermission(objectId, { userId, permCode });
     } catch (error: any) {
-      toast.error('Deleting object permission', error);
+      toast.error('Deleting object permission', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       await fetchObjectPermissions({ objectId: objectId });
       await mapObjectToUserPermissions(objectId);
@@ -141,7 +141,7 @@ export const usePermissionStore = defineStore('permission', () => {
       // Pass response back so bucketStore can handle bucketPerms=true correctly
       return response;
     } catch (error: any) {
-      toast.error('Fetching bucket permissions', error);
+      toast.error('Fetching bucket permissions', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -168,7 +168,7 @@ export const usePermissionStore = defineStore('permission', () => {
       // Pass response back so objectStore can handle bucketPerms=true correctly
       return response;
     } catch (error: any) {
-      toast.error('Fetching object permissions', error);
+      toast.error('Fetching object permissions', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -230,7 +230,7 @@ export const usePermissionStore = defineStore('permission', () => {
 
       state.mappedBucketToUserPermissions.value = userPermissions;
     } catch (error: any) {
-      toast.error('Mapping bucket permissions to user permissions', error);
+      toast.error('Mapping bucket permissions to user permissions', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -266,7 +266,7 @@ export const usePermissionStore = defineStore('permission', () => {
 
       state.mappedObjectToUserPermissions.value = userPermissions;
     } catch (error: any) {
-      toast.error('Mapping bucket permissions to user permissions', error);
+      toast.error('Mapping bucket permissions to user permissions', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -279,7 +279,7 @@ export const usePermissionStore = defineStore('permission', () => {
         await permissionService.bucketDeletePermission(bucketId, { userId, permCode: value });
       }
     } catch (error: any) {
-      toast.error('Removing bucket user', error);
+      toast.error('Removing bucket user', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       await fetchBucketPermissions({ bucketId: bucketId });
       await removeBucketUserMap(bucketId, userId);
@@ -304,7 +304,7 @@ export const usePermissionStore = defineStore('permission', () => {
         });
       }
     } catch (error: any) {
-      toast.error('Removing object user', error);
+      toast.error('Removing object user', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       await fetchObjectPermissions({ objectId: objectId });
       await removeObjectUserMap(objectId, userId);

--- a/frontend/src/store/tagStore.ts
+++ b/frontend/src/store/tagStore.ts
@@ -41,7 +41,7 @@ export const useTagStore = defineStore('tag', () => {
       await objectService.deleteTagging(objectId, tagging, versionId);
       await fetchTagging({ objectId: objectId });
     } catch (error: any) {
-      toast.error('Deleting tags', error);
+      toast.error('Deleting tags', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -64,7 +64,7 @@ export const useTagStore = defineStore('tag', () => {
       // Merge and assign
       state.tagging.value = difference.concat(response);
     } catch (error: any) {
-      toast.error('Fetching tags', error);
+      toast.error('Fetching tags', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -77,7 +77,7 @@ export const useTagStore = defineStore('tag', () => {
       await objectService.replaceTagging(objectId, tagging, versionId);
       await fetchTagging({ objectId: objectId });
     } catch (error: any) {
-      toast.error('Updating tags', error);
+      toast.error('Updating tags', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -90,7 +90,7 @@ export const useTagStore = defineStore('tag', () => {
       const response = (await objectService.searchTagging(tagset, bucketId)).data;
       state.tagSearchResults.value = response;
     } catch (error: any) {
-      toast.error('Searching tags', error);
+      toast.error('Searching tags', error.response?.data.detail ?? error, { life: 0 });
     }
   }
 

--- a/frontend/src/store/userStore.ts
+++ b/frontend/src/store/userStore.ts
@@ -69,7 +69,7 @@ export const useUserStore = defineStore('user', () => {
       // Merge and assign
       state.userSearch.value = difference.concat(response);
     } catch (error: any) {
-      toast.error('Searching users', error);
+      toast.error('Searching users', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }

--- a/frontend/src/store/versionStore.ts
+++ b/frontend/src/store/versionStore.ts
@@ -39,19 +39,20 @@ export const useVersionStore = defineStore('version', () => {
     getVersionsByObjectId: computed(
       () => (objectId: string) => state.versions.value.filter((x: Version) => x.objectId === objectId)
     ),
-    getIsDeleted: computed(() => (objectId: string) => state.versions.value.find((x: Version) =>
-      ((x.objectId === objectId) && (x.isLatest) && (x.deleteMarker))) ? true : false
+    getIsDeleted: computed(
+      () => (objectId: string) =>
+        state.versions.value.find((x: Version) => x.objectId === objectId && x.isLatest && x.deleteMarker)
+          ? true
+          : false
     ),
     getLatestVersionIdByObjectId: computed(
       () => (objectId: string) => state.versions.value.find((x: Version) => x.objectId === objectId && x.isLatest)?.id
     ),
     getLatestNonDmVersionIdByObjectId: computed(
-      () => (objectId: string) => state.versions.value
-        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-        .find((x: Version) =>
-          x.objectId === objectId &&
-          !x.deleteMarker
-        )?.id
+      () => (objectId: string) =>
+        state.versions.value
+          .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+          .find((x: Version) => x.objectId === objectId && !x.deleteMarker)?.id
     ),
     getIsVersioningEnabled: computed(
       () => (objectId: string) => state.versions.value.filter((x: Version) => x.objectId === objectId)[0]?.s3VersionId
@@ -81,7 +82,7 @@ export const useVersionStore = defineStore('version', () => {
         state.metadata.value = (await versionService.getMetadata(null, params)).data;
       }
     } catch (error: any) {
-      toast.error('Fetching metadata', error);
+      toast.error('Fetching metadata', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -97,7 +98,7 @@ export const useVersionStore = defineStore('version', () => {
         state.tagging.value = (await versionService.getObjectTagging(params)).data;
       }
     } catch (error: any) {
-      toast.error('Fetching tags', error);
+      toast.error('Fetching tags', error.response?.data.detail ?? error, { life: 0 });
     } finally {
       appStore.endIndeterminateLoading();
     }
@@ -130,7 +131,7 @@ export const useVersionStore = defineStore('version', () => {
     fetchMetadata,
     fetchTagging,
     fetchVersions,
-    findMetadataValue,
+    findMetadataValue
   };
 });
 

--- a/frontend/src/views/invite/InviteView.vue
+++ b/frontend/src/views/invite/InviteView.vue
@@ -83,7 +83,7 @@ onMounted(() => {
     .catch((error: any) => {
       const errData = error?.response?.data;
       if (errData.status) {
-        toast.error(errData.status, errData.detail);
+        toast.error(errData.status, errData.detail, { life: 0 });
         setErrorMessage(errData.status);
       }
       invalidInvite.value = true;

--- a/frontend/src/views/list/ListObjectsView.vue
+++ b/frontend/src/views/list/ListObjectsView.vue
@@ -30,7 +30,7 @@ const bucket: Ref<Bucket | undefined> = ref(undefined);
 
 onErrorCaptured((e: Error) => {
   const toast = useToast();
-  toast.error('Loading folder', e.message);
+  toast.error('Loading folder', e.message, { life: 0 });
 });
 
 onBeforeMount(async () => {

--- a/frontend/tests/unit/store/bucketStore.spec.ts
+++ b/frontend/tests/unit/store/bucketStore.spec.ts
@@ -139,7 +139,7 @@ describe('Bucket Store', () => {
       expect(searchBucketsSpy).toHaveBeenCalledTimes(1);
       expect(searchBucketsSpy).toBeCalledWith({ bucketId: ['000'] });
       expect(mockToast).toHaveBeenCalledTimes(1);
-      expect(mockToast).toHaveBeenCalledWith('Fetching buckets', new Error());
+      expect(mockToast).toHaveBeenCalledWith('Fetching buckets', new Error(), { life: 0 });
       expect(endIndeterminateLoadingSpy).toHaveBeenCalledTimes(1);
       expect(bucketStore.getBuckets).toStrictEqual([]);
     });

--- a/frontend/tests/unit/store/metadataStore.spec.ts
+++ b/frontend/tests/unit/store/metadataStore.spec.ts
@@ -72,7 +72,7 @@ describe('Metadata Store', () => {
       expect(getMetadataSpy).toHaveBeenCalledTimes(1);
       expect(getMetadataSpy).toHaveBeenCalledWith(null, { objectId: '000' });
       expect(mockToast).toHaveBeenCalledTimes(1);
-      expect(mockToast).toHaveBeenCalledWith('Fetching metadata', new Error());
+      expect(mockToast).toHaveBeenCalledWith('Fetching metadata', new Error(), { life: 0 });
       expect(endIndeterminateLoadingSpy).toHaveBeenCalledTimes(1);
       expect(metadataStore.getMetadata).toStrictEqual([]);
     });

--- a/frontend/tests/unit/store/objectStore.spec.ts
+++ b/frontend/tests/unit/store/objectStore.spec.ts
@@ -167,7 +167,7 @@ describe('Object Store', () => {
       expect(getObjectSpy).toHaveBeenCalledTimes(1);
       expect(getObjectSpy).toHaveBeenCalledWith(obj.id, undefined);
       expect(mockToast).toHaveBeenCalledTimes(1);
-      expect(mockToast).toHaveBeenCalledWith('Downloading object', new Error());
+      expect(mockToast).toHaveBeenCalledWith('Downloading object', new Error(), { life: 0 });
       expect(endIndeterminateLoadingSpy).toHaveBeenCalledTimes(1);
     });
   });
@@ -220,7 +220,7 @@ describe('Object Store', () => {
       //   {}
       // );
       expect(mockToast).toHaveBeenCalledTimes(1);
-      expect(mockToast).toHaveBeenCalledWith('Fetching objects', new Error());
+      expect(mockToast).toHaveBeenCalledWith('Fetching objects', new Error(), { life: 0 });
       expect(endIndeterminateLoadingSpy).toHaveBeenCalledTimes(1);
       expect(objectStore.getObjects).toStrictEqual([]);
     });

--- a/frontend/tests/unit/store/tagStore.spec.ts
+++ b/frontend/tests/unit/store/tagStore.spec.ts
@@ -72,7 +72,7 @@ describe('Config Store', () => {
       expect(getTaggingSpy).toHaveBeenCalledTimes(1);
       expect(getTaggingSpy).toHaveBeenCalledWith({ objectId: '000' });
       expect(mockToast).toHaveBeenCalledTimes(1);
-      expect(mockToast).toHaveBeenCalledWith('Fetching tags', new Error());
+      expect(mockToast).toHaveBeenCalledWith('Fetching tags', new Error(), { life: 0 });
       expect(endIndeterminateLoadingSpy).toHaveBeenCalledTimes(1);
       expect(tagStore.getTagging).toStrictEqual([]);
     });

--- a/frontend/tests/unit/store/userStore.spec.ts
+++ b/frontend/tests/unit/store/userStore.spec.ts
@@ -116,7 +116,7 @@ describe('User Store', () => {
       expect(searchForUsersSpy).toHaveBeenCalledWith({ lastName: 'bar' });
       expect(useToastSpy).toHaveBeenCalledTimes(1);
       expect(mockToast).toHaveBeenCalledTimes(1);
-      expect(mockToast).toHaveBeenCalledWith('Searching users', new Error());
+      expect(mockToast).toHaveBeenCalledWith('Searching users', new Error(), { life: 0 });
       expect(endIndeterminateLoadingSpy).toHaveBeenCalledTimes(1);
       expect(userStore.userSearch).toStrictEqual([]);
     });

--- a/frontend/tests/unit/store/versionStore.spec.ts
+++ b/frontend/tests/unit/store/versionStore.spec.ts
@@ -32,7 +32,7 @@ const version: Version = {
   s3VersionId: 's3123',
   isLatest: true,
   createdAt: '2023-05-01T22:18:12.553Z',
-  lastModifiedDate: '2023-05-01T22:18:12.553Z',
+  lastModifiedDate: '2023-05-01T22:18:12.553Z'
 };
 
 const versionOld: Version = {
@@ -43,7 +43,7 @@ const versionOld: Version = {
   s3VersionId: 's2000',
   isLatest: false,
   createdAt: '2022-05-01T18:25:42.462Z',
-  lastModifiedDate: '2023-05-01T22:18:12.553Z',
+  lastModifiedDate: '2023-05-01T22:18:12.553Z'
 };
 
 const mockToast = vi.fn();
@@ -106,7 +106,7 @@ describe('Version Store', () => {
       expect(getMetadataSpy).toHaveBeenCalledTimes(1);
       expect(getMetadataSpy).toHaveBeenCalledWith(null, { versionId: '000' });
       expect(mockToast).toHaveBeenCalledTimes(1);
-      expect(mockToast).toHaveBeenCalledWith('Fetching metadata', new Error());
+      expect(mockToast).toHaveBeenCalledWith('Fetching metadata', new Error(), { life: 0 });
       expect(endIndeterminateLoadingSpy).toHaveBeenCalledTimes(1);
       expect(versionStore.getMetadata).toStrictEqual([]);
     });
@@ -136,7 +136,7 @@ describe('Version Store', () => {
       expect(getTaggingSpy).toHaveBeenCalledTimes(1);
       expect(getTaggingSpy).toHaveBeenCalledWith({ versionId: '000' });
       expect(mockToast).toHaveBeenCalledTimes(1);
-      expect(mockToast).toHaveBeenCalledWith('Fetching tags', new Error());
+      expect(mockToast).toHaveBeenCalledWith('Fetching tags', new Error(), { life: 0 });
       expect(endIndeterminateLoadingSpy).toHaveBeenCalledTimes(1);
       expect(versionStore.getTagging).toStrictEqual([]);
     });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
<!-- Describe your changes in detail -->
The detailed COMS error response message (specifically, the `detail` field) is now displayed in the toast body instead. Previously, only the HTTP response code and a generic `AxiosError` message is displayed.

**Example:** updating a bucket using invalid S3 credentials

_Before:_
  > **Error: Configuring storage location source**
  > AxiosError: Request failed with status code 409

_After:_
  > **Error: Configuring storage location source**
  > Unable to validate supplied credentials for the bucket 

Also, error notifications no longer disappear automatically; they must be closed manually instead.

<!-- Why is this change required? What problem does it solve? -->
This should make it easier for users to diagnose basic errors, without having to reach out to us every time.

<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-3941](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-3941)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
```js
error.response?.data.detail ?? error
```
If the error isn't coming from the COMS API (or if COMS fails to return a properly-formatted error response as per the API spec), the toast message will fallback to the raw error itself, as was the case previously.